### PR TITLE
Add links to Verity upstream documentation throughout site

### DIFF
--- a/site/src/components/SiteFooter.astro
+++ b/site/src/components/SiteFooter.astro
@@ -30,6 +30,7 @@ const year = new Date().getFullYear();
       <div>
         <h4>Project</h4>
         <a href="https://github.com/bacon-labs/tama" rel="noopener">GitHub</a>
+        <a href="https://veritylang.com" rel="noopener">Verity docs</a>
         <a href="/troubleshooting">Troubleshooting</a>
         <a href="/privacy">Privacy</a>
       </div>

--- a/site/src/pages/concepts.mdx
+++ b/site/src/pages/concepts.mdx
@@ -10,14 +10,15 @@ import Callout from "../components/Callout.astro";
 
 ## What is Verity?
 
-**Verity is a way of writing smart contracts where the contract and its
+**[Verity](https://veritylang.com) is a way of writing smart contracts where the contract and its
 intended behavior are written down separately, and a machine checks
 that they agree.**
 
 Three layers, in one project:
 
 1. **Implementation** — the code that runs on the EVM.
-   Written in a Lean DSL that looks much like Solidity, compiled to Yul, then to bytecode.
+   Written in a [Lean EDSL](https://veritylang.com/core) that looks much
+   like Solidity, compiled to Yul, then to bytecode.
 2. **Specification** — what the implementation must do. Invariants
    ("the total never exceeds the cap"), postconditions ("after `transfer`,
    the sender's balance drops by exactly the amount"), frame conditions
@@ -182,3 +183,7 @@ Every term above is a piece of that promise.
 - [Your first contract](/start) — the tutorial that uses every term above.
 - [CLI reference](/reference/cli) — what each command actually does.
 - [Manifest schema](/reference/manifest) — the canonical JSON shape.
+- [Verity EDSL reference](https://veritylang.com/core) — the storage,
+  state, and `require` primitives every implementation is built from.
+- [Writing a Verity contract](https://veritylang.com/guides/first-contract)
+  — the upstream walkthrough through spec, implementation, and proof.

--- a/site/src/pages/guides/audits.mdx
+++ b/site/src/pages/guides/audits.mdx
@@ -147,6 +147,11 @@ What it inspects:
 - Compiler trust-surface artifacts (`artifacts/trust-report.json`,
   `artifacts/assumption-report.json`).
 
+The compiler artifacts come straight from the Verity framework; see
+[Verity's `TRUST_ASSUMPTIONS.md`](https://github.com/lfglabs-dev/verity/blob/main/TRUST_ASSUMPTIONS.md)
+for what the framework itself takes on trust before any project-level
+allowlist enters the picture.
+
 A real failure:
 
 ```text

--- a/site/src/pages/guides/proofs.mdx
+++ b/site/src/pages/guides/proofs.mdx
@@ -146,7 +146,9 @@ explicitly:
 ```
 
 The string is the audit-visible reason. Don't allowlist anything you can't
-defend in two sentences.
+defend in two sentences. Verity itself ships with
+[zero documented axioms](https://github.com/lfglabs-dev/verity/blob/main/AXIOMS.md);
+anything you allowlist is a project-level choice, not a framework one.
 
 ## Where to look when a proof won't close
 
@@ -157,6 +159,9 @@ defend in two sentences.
 - Inside Lean, `simp?` and `exact?` will often suggest the lemma name
   you're missing; `omega` closes nearly all linear arithmetic goals;
   `decide` closes small decidable propositions.
+- [Verity's debugging-proofs guide](https://veritylang.com/guides/debugging-proofs)
+  catalogues the common error messages and tactic patterns from the
+  Verity side — start here before reaching for `sorry`.
 - Read [the audit guide](/guides/audits) — many "proof failures" are
   actually structural mistakes (e.g. an obligation pointing at a
   non-existent mirror) that the audit reports more clearly than the

--- a/site/src/pages/limitations.mdx
+++ b/site/src/pages/limitations.mdx
@@ -43,7 +43,9 @@ The pinned Verity macro syntax used by the starter does not currently
 expose event declarations for `verity_contract`, so the generated
 `ERC20Lite` starter does not emit ERC20 `Transfer` events in v0.1.
 Event ABI parsing and manifest validation **are** supported for compiler
-outputs that do include event metadata.
+outputs that do include event metadata. The
+[Verity EDSL reference](https://veritylang.com/core) tracks what the
+language exposes as the framework moves forward.
 
 `Counter` is a compatibility fixture, not the starter template.
 

--- a/site/src/pages/reference/config.mdx
+++ b/site/src/pages/reference/config.mdx
@@ -49,7 +49,7 @@ metadata_bytecode_hash = "none"
 | Key       | Required | Description                                       |
 | --------- | -------- | ------------------------------------------------- |
 | `name`    | yes      | Project name (matches `lakefile.toml`).           |
-| `verity`  | yes      | Verity framework tag or commit. Pinned in lock.   |
+| `verity`  | yes      | [Verity](https://veritylang.com) framework tag or commit. Pinned in lock. |
 
 ### `[paths]`
 

--- a/site/src/pages/start.mdx
+++ b/site/src/pages/start.mdx
@@ -29,6 +29,10 @@ By the end of this tutorial you will have:
 - `tama` installed (see [Install](/install)).
 - Comfort reading Solidity. You do **not** need prior Lean or Verity experience.
 - About 20 minutes.
+
+The [Verity EDSL reference](https://veritylang.com/core) explains the
+language we'll be writing in if you'd like a deeper look at any line
+along the way.
 </Callout>
 
 ## Step 1 — Scaffold a project
@@ -187,6 +191,8 @@ Each theorem says: *if the invariant holds before the call, it holds
 after the call.* The `by simp [...]` is the proof — Lean's simplifier
 unfolds the definitions and the lemmas listed, and Verity's standard
 library takes care of the mapping arithmetic.
+[Verity's debugging-proofs guide](https://veritylang.com/guides/debugging-proofs)
+catalogues the tactics and error messages you'll meet most often.
 
 The two `@[tama.mirror "..."]` annotations point at a Foundry test
 we'll write next. This is what links a proven property to an executable
@@ -333,3 +339,7 @@ with one keystroke.
 - **[Writing proof obligations](/guides/proofs)** — patterns for spec
   decomposition, frame conditions, and helper lemmas.
 - **[CLI reference](/reference/cli)** — every flag for every command.
+- **[Verity EDSL reference](https://veritylang.com/core)** — the language
+  we wrote the contract in, in detail.
+- **[Verity examples](https://veritylang.com/examples)** — the upstream
+  contracts, each one introducing a new pattern.


### PR DESCRIPTION
This PR adds references and links to the upstream Verity framework documentation across the tama site, improving discoverability of language reference materials and guides for users.

## Summary
Enhanced documentation navigation by linking to relevant Verity upstream resources (veritylang.com) at strategic points in the tama documentation, helping users find deeper language references and debugging guides when needed.

## Key changes

- **Getting started**: Added reference to Verity EDSL reference in the prerequisites section and linked debugging-proofs guide after theorem explanation in the tutorial
- **Concepts page**: Linked "Lean EDSL" terminology to the upstream reference and added related resources section with links to EDSL reference, first-contract guide, and examples
- **Proofs guide**: Added link to Verity's debugging-proofs guide in the "where to look when a proof won't close" section; clarified axiom allowlisting with link to Verity's AXIOMS.md
- **Audits guide**: Added context about compiler artifacts with link to Verity's TRUST_ASSUMPTIONS.md
- **Limitations page**: Linked Verity EDSL reference when discussing event declaration limitations
- **Config reference**: Linked "Verity" term to veritylang.com in the configuration table
- **Site footer**: Added "Verity docs" link in the Project section

## Implementation details

All changes are documentation-only, adding hyperlinks to upstream Verity resources (https://veritylang.com) at contextually relevant locations. No functional changes to the tama codebase itself.

https://claude.ai/code/session_01H5N1VGyPfqLEmqCut41V4B