### PR TITLE
Add starter CI plan doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,15 @@ jobs:
       - uses: ./.github/actions/install-toolchain
       - name: Build Tama
         run: cargo build --workspace
+      - name: Install actionlint
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused \
+            https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash \
+            -o "$RUNNER_TEMP/download-actionlint.bash"
+          bash "$RUNNER_TEMP/download-actionlint.bash" 1.7.7 "$RUNNER_TEMP/actionlint-bin"
+          echo "$RUNNER_TEMP/actionlint-bin" >> "$GITHUB_PATH"
       - name: Fresh starter quickstart
         shell: bash
         run: |
@@ -75,6 +84,9 @@ jobs:
           project="$tmp/my-protocol"
           tama init "$project"
           cd "$project"
+          test -f .github/workflows/ci.yml
+          test -f .gitignore
+          actionlint -color .github/workflows/ci.yml
           tama doctor
           tama check
           tama build --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/actionlint-bin"
           curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused \
             https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash \
             -o "$RUNNER_TEMP/download-actionlint.bash"
-          bash "$RUNNER_TEMP/download-actionlint.bash" 1.7.7 "$RUNNER_TEMP/actionlint-bin"
+          bash "$RUNNER_TEMP/download-actionlint.bash" 1.7.12 "$RUNNER_TEMP/actionlint-bin"
           echo "$RUNNER_TEMP/actionlint-bin" >> "$GITHUB_PATH"
       - name: Fresh starter quickstart
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -445,7 +445,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -606,7 +606,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -643,6 +643,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "semver"
@@ -700,6 +706,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -912,6 +931,7 @@ dependencies = [
  "camino",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "tama-common",
  "tama-config",
@@ -1135,6 +1155,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/crates/tama-project/Cargo.toml
+++ b/crates/tama-project/Cargo.toml
@@ -17,4 +17,5 @@ thiserror.workspace = true
 toml_edit.workspace = true
 
 [dev-dependencies]
+serde_yaml = "0.9"
 tempfile.workspace = true

--- a/crates/tama-project/src/lib.rs
+++ b/crates/tama-project/src/lib.rs
@@ -13,6 +13,7 @@ const DEFAULT_VERITY_REV: &str = "9b0114efcc0af589af63dd3f2eafcdf1a24dbf1e";
 const DEFAULT_LEAN_TOOLCHAIN: &str = "leanprover/lean4:v4.22.0";
 const DEFAULT_SOLC: &str = "0.8.33";
 const STARTER_LAKE_MANIFEST: &str = include_str!("templates/starter-lake-manifest.json");
+const STARTER_CI_WORKFLOW: &str = include_str!("templates/starter-ci.yml");
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -90,6 +91,7 @@ pub fn init(path: &Utf8Path, opts: InitOptions) -> Result<()> {
         "artifacts/lean",
         "artifacts/trust-probe",
         "docs",
+        ".github/workflows",
     ] {
         fs::create_dir_all(path.join(dir))
             .map_err(|source| tama_common::io_error(path.join(dir), source))?;
@@ -138,6 +140,8 @@ pub fn init(path: &Utf8Path, opts: InitOptions) -> Result<()> {
         ERC20LITE_DEPLOYER_SOL,
     )?;
     write_string(&path.join("docs/README.md"), STARTER_README)?;
+    write_string(&path.join(".github/workflows/ci.yml"), STARTER_CI_WORKFLOW)?;
+    write_string(&path.join(".gitignore"), STARTER_GITIGNORE)?;
 
     let mut lock = TamaLock {
         version: 1,
@@ -523,6 +527,8 @@ solc_version = "0.8.33"
 fs_permissions = [{ access = "read", path = "./artifacts" }]
 "#;
 
+const STARTER_GITIGNORE: &str = "/.lake/\n/artifacts/\n/cache/\n/lib/\n/out/\nfoundry.lock\n";
+
 const ERC20LITE_LEAN: &str = r#"import Contracts.Common
 
 namespace src
@@ -869,6 +875,13 @@ forge script script/ERC20Lite.s.sol:DeployERC20Lite --broadcast --rpc-url <url>
 ```
 
 Set `ERC20LITE_OWNER=<address>` to choose an owner other than Foundry's sender.
+
+## Continuous integration
+
+`.github/workflows/ci.yml` runs `tama doctor`, `tama check`, `tama build
+--locked`, `tama test`, and `tama audit` on every push and pull request. The
+first run installs Lean (elan), Foundry, solc 0.8.33, and Tama; later runs
+reuse caches keyed on `lake-manifest.json` and `tama.lock`.
 "#;
 
 #[cfg(test)]
@@ -1017,6 +1030,72 @@ metadata_bytecode_hash = "none"
         );
         assert!(lock.inputs.contains_key("lake-manifest.json"));
         assert!(tama_config::lock_drift(&root, &lock).unwrap().is_empty());
+    }
+
+    #[test]
+    fn init_creates_github_actions_workflow() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(dir.path().join("starter")).unwrap();
+        init(&root, InitOptions::default()).unwrap();
+        let workflow_path = root.join(".github/workflows/ci.yml");
+        assert!(workflow_path.is_file());
+        let workflow = read_to_string(&workflow_path).unwrap();
+        for needle in [
+            "name: CI",
+            "tama doctor",
+            "tama check",
+            "tama build --locked",
+            "tama test",
+            "tama audit",
+            "foundry-rs/foundry-toolchain",
+            "solc-select",
+            "https://tama.tools/install.sh",
+        ] {
+            assert!(
+                workflow.contains(needle),
+                "starter workflow missing `{needle}`"
+            );
+        }
+        let starter_readme = read_to_string(&root.join("docs/README.md")).unwrap();
+        assert!(starter_readme.contains("Continuous integration"));
+        assert!(starter_readme.contains(".github/workflows/ci.yml"));
+    }
+
+    #[test]
+    fn init_creates_gitignore() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(dir.path().join("starter")).unwrap();
+        init(&root, InitOptions::default()).unwrap();
+        let gitignore = read_to_string(&root.join(".gitignore")).unwrap();
+        for entry in [
+            "/.lake/",
+            "/artifacts/",
+            "/cache/",
+            "/lib/",
+            "/out/",
+            "foundry.lock",
+        ] {
+            assert!(
+                gitignore.contains(entry),
+                "starter .gitignore missing `{entry}`"
+            );
+        }
+    }
+
+    #[test]
+    fn starter_ci_workflow_is_valid_yaml() {
+        let parsed: serde_yaml::Value =
+            serde_yaml::from_str(STARTER_CI_WORKFLOW).expect("starter-ci.yml must be valid YAML");
+        let steps = parsed
+            .get("jobs")
+            .and_then(|jobs| jobs.get("verify"))
+            .and_then(|verify| verify.get("steps"))
+            .and_then(|steps| steps.as_sequence())
+            .expect("starter-ci.yml must declare jobs.verify.steps as a sequence");
+        assert!(
+            !steps.is_empty(),
+            "starter-ci.yml jobs.verify.steps must not be empty"
+        );
     }
 
     #[test]

--- a/crates/tama-project/src/lib.rs
+++ b/crates/tama-project/src/lib.rs
@@ -527,7 +527,7 @@ solc_version = "0.8.33"
 fs_permissions = [{ access = "read", path = "./artifacts" }]
 "#;
 
-const STARTER_GITIGNORE: &str = "/.lake/\n/artifacts/\n/cache/\n/lib/\n/out/\nfoundry.lock\n";
+const STARTER_GITIGNORE: &str = "/.lake/\n/artifacts/\n/cache/\n/out/\nfoundry.lock\n";
 
 const ERC20LITE_LEAN: &str = r#"import Contracts.Common
 
@@ -1067,19 +1067,19 @@ metadata_bytecode_hash = "none"
         let root = Utf8PathBuf::from_path_buf(dir.path().join("starter")).unwrap();
         init(&root, InitOptions::default()).unwrap();
         let gitignore = read_to_string(&root.join(".gitignore")).unwrap();
-        for entry in [
-            "/.lake/",
-            "/artifacts/",
-            "/cache/",
-            "/lib/",
-            "/out/",
-            "foundry.lock",
-        ] {
+        for entry in ["/.lake/", "/artifacts/", "/cache/", "/out/", "foundry.lock"] {
             assert!(
                 gitignore.contains(entry),
                 "starter .gitignore missing `{entry}`"
             );
         }
+        assert!(
+            !gitignore.lines().any(|line| line.trim() == "/lib/"
+                || line.trim() == "lib/"
+                || line.trim() == "/lib"
+                || line.trim() == "lib"),
+            "starter .gitignore must not exclude lib/ — `forge install` adds submodules under it"
+        );
     }
 
     #[test]

--- a/crates/tama-project/src/templates/starter-ci.yml
+++ b/crates/tama-project/src/templates/starter-ci.yml
@@ -1,0 +1,105 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TAMA_LAKE_PACKAGE_CACHE: ${{ github.workspace }}/.cache/tama/lake-packages
+
+jobs:
+  verify:
+    name: tama verify
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache Lake packages and Tama artifacts
+        uses: actions/cache@v4
+        with:
+          path: .cache/tama
+          key: tama-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lake-manifest.json', 'tama.lock') }}
+          restore-keys: |
+            tama-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Cache elan and Foundry toolchains
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.elan
+            ~/.foundry
+          key: toolchain-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain', 'tama.lock') }}
+          restore-keys: |
+            toolchain-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Add toolchain bin directories to PATH
+        run: |
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.foundry/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.tama/bin" >> "$GITHUB_PATH"
+
+      - name: Install elan (Lean toolchain manager)
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4; do
+            if curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused \
+                https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+                -o "$RUNNER_TEMP/elan-init.sh"; then
+              sh "$RUNNER_TEMP/elan-init.sh" -y --default-toolchain none && exit 0
+            fi
+            sleep $((attempt * 5))
+          done
+          echo "elan install failed after 4 attempts" >&2
+          exit 1
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1.6.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Install solc 0.8.33 via solc-select
+        run: |
+          set -euo pipefail
+          venv="$RUNNER_TEMP/solc-select-venv"
+          python3 -m venv "$venv"
+          for attempt in 1 2 3 4; do
+            "$venv/bin/pip" install --upgrade solc-select && break || sleep $((attempt * 5))
+          done
+          for attempt in 1 2 3 4; do
+            "$venv/bin/solc-select" install 0.8.33 && break || sleep $((attempt * 5))
+          done
+          "$venv/bin/solc-select" use 0.8.33
+          echo "$venv/bin" >> "$GITHUB_PATH"
+
+      # Set TAMA_VERSION (e.g. "0.1.0") to pin a specific Tama release.
+      - name: Install Tama
+        env:
+          TAMA_VERSION: ""
+        run: |
+          set -euo pipefail
+          curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused \
+            https://tama.tools/install.sh | sh
+          if [ -n "$TAMA_VERSION" ]; then
+            "$HOME/.tama/bin/tamaup" install "$TAMA_VERSION"
+          fi
+
+      - name: Print toolchain versions
+        run: |
+          tama --version
+          forge --version
+          solc --version
+
+      - run: tama doctor
+      - run: tama check
+      - run: tama build --locked
+      - run: tama test
+      - run: tama audit

--- a/crates/tama-project/src/templates/starter-ci.yml
+++ b/crates/tama-project/src/templates/starter-ci.yml
@@ -43,9 +43,11 @@ jobs:
 
       - name: Add toolchain bin directories to PATH
         run: |
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-          echo "$HOME/.foundry/bin" >> "$GITHUB_PATH"
-          echo "$HOME/.tama/bin" >> "$GITHUB_PATH"
+          {
+            echo "$HOME/.elan/bin"
+            echo "$HOME/.foundry/bin"
+            echo "$HOME/.tama/bin"
+          } >> "$GITHUB_PATH"
 
       - name: Install elan (Lean toolchain manager)
         run: |
@@ -72,10 +74,16 @@ jobs:
           venv="$RUNNER_TEMP/solc-select-venv"
           python3 -m venv "$venv"
           for attempt in 1 2 3 4; do
-            "$venv/bin/pip" install --upgrade solc-select && break || sleep $((attempt * 5))
+            if "$venv/bin/pip" install --upgrade solc-select; then
+              break
+            fi
+            sleep $((attempt * 5))
           done
           for attempt in 1 2 3 4; do
-            "$venv/bin/solc-select" install 0.8.33 && break || sleep $((attempt * 5))
+            if "$venv/bin/solc-select" install 0.8.33; then
+              break
+            fi
+            sleep $((attempt * 5))
           done
           "$venv/bin/solc-select" use 0.8.33
           echo "$venv/bin" >> "$GITHUB_PATH"

--- a/docs/STARTER_CI_PLAN.md
+++ b/docs/STARTER_CI_PLAN.md
@@ -1,0 +1,166 @@
+# Starter CI plan
+
+## Purpose
+
+`tama init` scaffolds a complete buildable project — Verity Lean source, spec,
+proof, mirror Foundry tests, generated bridge, deploy script, lakefile,
+foundry.toml, and a `tama.lock` — but it writes no CI configuration. A user
+who runs `tama init my-protocol`, pushes to GitHub, and opens a pull request
+gets zero automated verification: a stale `tama.lock`, a broken proof, a
+mutated artifact, or a failing Foundry mirror surface only when someone runs
+`tama` locally. This plan extends the `init` template so every freshly
+scaffolded project ships a `.github/workflows/ci.yml` that installs the
+toolchain, builds with `--locked`, runs the Foundry mirrors, and runs the
+audit suite on every push and pull request.
+
+## Steps
+
+1. **Create the workflow template at
+   `crates/tama-project/src/templates/starter-ci.yml`.** Single workflow file,
+   not a matrix. Top-level fields:
+
+   - `name: CI`
+   - `on: { pull_request: {}, push: { branches: [main] } }`
+   - `permissions: { contents: read }`
+   - `concurrency: { group: ci-${{ github.ref }}, cancel-in-progress: true }`
+   - `env: { TAMA_LAKE_PACKAGE_CACHE: ${{ github.workspace }}/.cache/tama/lake-packages }`
+
+   One job `verify` on `ubuntu-22.04` with these steps, in order:
+
+   1. `actions/checkout@v4`.
+   2. `actions/cache@v4` for `.cache/tama` keyed on
+      `${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lake-manifest.json', 'tama.lock') }}`
+      with a restore-keys prefix that drops the hash suffix.
+   3. `actions/cache@v4` for `~/.elan` and `~/.foundry` keyed on
+      `${{ runner.os }}-${{ runner.arch }}-toolchain-${{ hashFiles('lean-toolchain', 'tama.lock') }}`.
+   4. Install elan with the retry-tolerant block copied from
+      `.github/actions/install-toolchain/action.yml:26-39` — four attempts,
+      `--default-toolchain none`, append `$HOME/.elan/bin` to `$GITHUB_PATH`.
+   5. `foundry-rs/foundry-toolchain@v1.6.0` with
+      `env: { GITHUB_TOKEN: ${{ github.token }} }`.
+   6. solc-select 0.8.33 in a venv, identical to
+      `.github/actions/install-toolchain/action.yml:46-59`.
+   7. Install Tama: `curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused
+      https://tama.tools/install.sh | sh`, then append `$HOME/.tama/bin` to
+      `$GITHUB_PATH`. Pin the install via `TAMA_VERSION` env defaulting to
+      empty (latest); leave a comment in the file showing how to set it.
+   8. `tama doctor`.
+   9. `tama check`.
+   10. `tama build --locked`.
+   11. `tama test`.
+   12. `tama audit`.
+
+   The file lives in `templates/` alongside `starter-lake-manifest.json` so it
+   is shipped with the crate via `include_str!` and is discoverable by anyone
+   reading the templates directory.
+
+2. **Add the `STARTER_CI_WORKFLOW` constant in
+   `crates/tama-project/src/lib.rs`.** Put it next to the existing
+   `STARTER_LAKE_MANIFEST` constant at line 15:
+
+   ```rust
+   const STARTER_CI_WORKFLOW: &str = include_str!("templates/starter-ci.yml");
+   ```
+
+3. **Wire the template into `init()` in
+   `crates/tama-project/src/lib.rs`.** In the directory list at lines 77-93,
+   add `".github/workflows"` so the parent directory exists. After the
+   `write_string(&path.join("docs/README.md"), STARTER_README)?` call at line
+   140, append:
+
+   ```rust
+   write_string(
+       &path.join(".github/workflows/ci.yml"),
+       STARTER_CI_WORKFLOW,
+   )?;
+   ```
+
+4. **Generate `.gitignore` from `init()`.** The starter currently produces no
+   `.gitignore`, so the first `git add` after `tama init` stages every build
+   output. After the workflow write in step 3, also write `path.join(".gitignore")`
+   with the contents of `fixtures/projects/counter/.gitignore`
+   (`/.lake/`, `/artifacts/`, `/cache/`, `/lib/`, `/out/`, `foundry.lock`).
+   Define a `STARTER_GITIGNORE` constant alongside `FOUNDRY_TOML` at line 517.
+
+5. **Add a unit test
+   `init_creates_github_actions_workflow` in the `mod tests` block of
+   `crates/tama-project/src/lib.rs` (after
+   `init_creates_erc20lite_starter_without_foundry_counter` at line 934).**
+   The test calls `init`, reads `.github/workflows/ci.yml`, and asserts the
+   file contains the literal substrings `name: CI`, `tama doctor`,
+   `tama check`, `tama build --locked`, `tama test`, and `tama audit`. Add a
+   second test `init_creates_gitignore` that asserts the `.gitignore`
+   contains `/.lake/` and `/artifacts/`.
+
+6. **Cover the workflow YAML structure with a parse test in the same `mod
+   tests` block.** Add `serde_yaml = "0.9"` as a `dev-dependencies` entry in
+   `crates/tama-project/Cargo.toml`. Test
+   `starter_ci_workflow_is_valid_yaml` runs
+   `serde_yaml::from_str::<serde_yaml::Value>(STARTER_CI_WORKFLOW).unwrap()`
+   and asserts the parsed root has `jobs.verify.steps` as a non-empty
+   sequence. This catches indentation and quoting regressions on the embedded
+   template before they ship.
+
+7. **Update `STARTER_README` in `crates/tama-project/src/lib.rs:850-872` to
+   document the workflow.** Add a final section:
+
+   ```markdown
+   ## Continuous integration
+
+   `.github/workflows/ci.yml` runs `tama doctor`, `tama check`, `tama build
+   --locked`, `tama test`, and `tama audit` on every push and pull request.
+   The first run installs Lean (elan), Foundry, solc 0.8.33, and Tama; later
+   runs reuse caches keyed on `lake-manifest.json` and `tama.lock`.
+   ```
+
+8. **Extend the `real-e2e` smoke check at
+   `.github/workflows/ci.yml:69-99`.** After `tama init "$project"`, assert
+   the generated workflow exists and parses:
+
+   ```bash
+   test -f "$project/.github/workflows/ci.yml"
+   python3 -c "import sys, yaml; yaml.safe_load(open(sys.argv[1]))" \
+     "$project/.github/workflows/ci.yml"
+   ```
+
+   Install `python3-yaml` (or `pip install pyyaml` in a temp venv) earlier in
+   the job. This guards against the in-process YAML parse test (step 6)
+   missing template substitutions a future template-parameterization step
+   might introduce.
+
+9. **Add an `actionlint` lint of the generated workflow in the same
+   `real-e2e` job.** Run
+   `curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash`
+   then `./actionlint -color "$project/.github/workflows/ci.yml"`. Pin the
+   actionlint version via the script's `INSTALL_VERSION` env to the latest
+   tagged release at the time of plan execution.
+
+10. **Update `crates/tama-project/src/lib.rs` doc-comment at the top of the
+    file** so the list of files `init` produces names `.github/workflows/ci.yml`
+    and `.gitignore`. The file currently has no module-level doc; add one
+    that enumerates the generated tree so future contributors do not need
+    to read `init()` line by line.
+
+## End state
+
+- `crates/tama-project/src/templates/starter-ci.yml` exists and is included
+  via `include_str!`.
+- Running `tama init <path>` on an empty directory creates
+  `<path>/.github/workflows/ci.yml` and `<path>/.gitignore`.
+- The generated workflow file declares the steps `tama doctor`,
+  `tama check`, `tama build --locked`, `tama test`, and `tama audit` in that
+  order, on a single `ubuntu-22.04` job.
+- The generated workflow installs elan, Foundry, solc 0.8.33, and Tama, in
+  that order, before the verification steps.
+- `cargo test -p tama-project` exercises:
+  - `init_creates_github_actions_workflow` (substring assertions)
+  - `init_creates_gitignore`
+  - `starter_ci_workflow_is_valid_yaml` (full YAML parse)
+- `.github/workflows/ci.yml` `real-e2e` job runs `actionlint` and
+  `yaml.safe_load` against the workflow generated by `tama init` in a fresh
+  starter, and fails if either rejects it.
+- `docs/README.md` inside a freshly initialized starter contains a
+  "Continuous integration" section pointing at the workflow file.
+- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D
+  warnings`, `cargo test --workspace`, and `cargo build --workspace
+  --release` all pass on the branch.


### PR DESCRIPTION
Plan for shipping `.github/workflows/ci.yml` and `.gitignore` from
`tama init` so freshly scaffolded projects run `tama doctor` / `check` /
`build --locked` / `test` / `audit` on every push and pull request.

https://claude.ai/code/session_01WUjhL6aBpvFEU4UvkkoxGS