### PR TITLE
Acquire ENV_LOCK in ensure_git_worktree test to fix CI race

### DIFF
--- a/crates/tama-cli/src/main.rs
+++ b/crates/tama-cli/src/main.rs
@@ -3256,6 +3256,7 @@ mod tests {
 
     #[test]
     fn ensure_git_worktree_initializes_fresh_project_root() {
+        let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
         let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
         assert!(!is_git_worktree(&root).unwrap());


### PR DESCRIPTION
ensure_git_worktree_initializes_fresh_project_root shells out to real
`git` via PATH lookup but did not take ENV_LOCK. Other tama-cli tests
prepend a fake-`git` stub to PATH while holding ENV_LOCK; when scheduled
in parallel this test resolved to the stub and `git init` exited with
status 127, surfacing only on release CI's parallel runs.

Same pattern as a54be09 — readers of PATH must serialize against
mutators. This was the last git-shelling test missing the guard.