### PR TITLE
Remove macOS x86_64 release target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -369,8 +369,6 @@ jobs:
             os: ubuntu-22.04
           - platform: linux-aarch64
             os: ubuntu-24.04-arm
-          - platform: macos-x86_64
-            os: macos-13
           - platform: macos-aarch64
             os: macos-14
     steps:
@@ -431,7 +429,6 @@ jobs:
               "linux-aarch64",
               "linux-x86_64",
               "macos-aarch64",
-              "macos-x86_64",
           }
           for raw in sys.argv[3:]:
               path = pathlib.Path(raw)

--- a/crates/tamaup-cli/src/main.rs
+++ b/crates/tamaup-cli/src/main.rs
@@ -987,17 +987,12 @@ fn tama_home() -> Utf8PathBuf {
 }
 
 fn platform() -> Result<String, String> {
-    let os = match std::env::consts::OS {
-        "linux" => "linux",
-        "macos" => "macos",
-        other => return Err(format!("unsupported OS for Tama v0.1: {other}")),
-    };
-    let arch = match std::env::consts::ARCH {
-        "x86_64" => "x86_64",
-        "aarch64" => "aarch64",
-        other => return Err(format!("unsupported architecture for Tama v0.1: {other}")),
-    };
-    Ok(format!("{os}-{arch}"))
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("linux", "x86_64") => Ok("linux-x86_64".to_string()),
+        ("linux", "aarch64") => Ok("linux-aarch64".to_string()),
+        ("macos", "aarch64") => Ok("macos-aarch64".to_string()),
+        (os, arch) => Err(format!("unsupported platform for Tama v0.1: {os}-{arch}")),
+    }
 }
 
 #[cfg(test)]

--- a/docs/reference/IMPLEMENTATION_PLAN.md
+++ b/docs/reference/IMPLEMENTATION_PLAN.md
@@ -12,7 +12,7 @@ Tama v0.1 is production-ready when it is reliable inside its declared scope, not
 
 ### In scope for v0.1
 
-- Linux x86_64, Linux aarch64, macOS x86_64, macOS aarch64.
+- Linux x86_64, Linux aarch64, macOS aarch64.
 - No Windows support.
 - Flat Verity project layout:
   - `verity/src/Foo.lean`
@@ -1134,7 +1134,7 @@ If Verity cannot support one of these features, the phase must not fake it. The 
 #### Work
 
 1. POSIX shell; ShellCheck clean.
-2. Supports Linux/macOS x86_64/aarch64 only.
+2. Supports Linux x86_64/aarch64 and macOS aarch64 only.
 3. Downloads:
    - `manifest.json`
    - `manifest.json.minisig`

--- a/docs/reference/RELEASE.md
+++ b/docs/reference/RELEASE.md
@@ -22,11 +22,10 @@ The CI workflow lives in `.github/workflows/ci.yml` and includes:
 
 ## Artifacts
 
-Build four platform archives:
+Build three platform archives:
 
 - `linux-x86_64`
 - `linux-aarch64`
-- `macos-x86_64`
 - `macos-aarch64`
 
 Each archive contains `tama` and `tamaup`. No Windows archive is published for v0.1.

--- a/docs/reference/SPEC.md
+++ b/docs/reference/SPEC.md
@@ -851,7 +851,6 @@ Supported platforms:
 ```text
 linux-x86_64
 linux-aarch64
-macos-x86_64
 macos-aarch64
 ```
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -12,7 +12,6 @@ fi
 case "$(uname -s):$(uname -m)" in
   Linux:x86_64) PLATFORM="linux-x86_64" ;;
   Linux:aarch64|Linux:arm64) PLATFORM="linux-aarch64" ;;
-  Darwin:x86_64) PLATFORM="macos-x86_64" ;;
   Darwin:arm64|Darwin:aarch64) PLATFORM="macos-aarch64" ;;
   *) echo "unsupported platform: $(uname -s):$(uname -m)" >&2; exit 1 ;;
 esac

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -12,7 +12,6 @@ fi
 case "$(uname -s):$(uname -m)" in
   Linux:x86_64) PLATFORM="linux-x86_64" ;;
   Linux:aarch64|Linux:arm64) PLATFORM="linux-aarch64" ;;
-  Darwin:x86_64) PLATFORM="macos-x86_64" ;;
   Darwin:arm64|Darwin:aarch64) PLATFORM="macos-aarch64" ;;
   *) echo "unsupported platform: $(uname -s):$(uname -m)" >&2; exit 1 ;;
 esac


### PR DESCRIPTION
Drop macos-x86_64 from the release build matrix, manifest expectations,
installer scripts, tamaup platform detection, and supported-platform
docs. Tama v0.1 now ships only linux-x86_64, linux-aarch64, and
macos-aarch64 archives.