### PR TITLE
Drop github-pages environment from release publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -396,9 +396,6 @@ jobs:
     name: Publish signed release
     runs-on: ubuntu-22.04
     needs: build-artifacts
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
The publish job in release.yml only ships release artifacts via
softprops/action-gh-release; it never calls actions/deploy-pages and
the referenced steps.deploy output doesn't exist. Declaring
environment: github-pages caused tag pushes (e.g. v0.1.0) to be
rejected by Pages environment protection rules. Pages content is
already deployed by deploy-docs.yml on push to main.