### PR TITLE
Make `-- tama:` the canonical obligation-marker syntax

### DIFF
--- a/crates/tama-build/src/lib.rs
+++ b/crates/tama-build/src/lib.rs
@@ -1473,10 +1473,6 @@ fn parse_obligation_metadata(
         parsed = true;
         apply_tama_metadata(raw, proof_path, meta)?;
     }
-    if line.contains("tama.") {
-        parsed = true;
-        apply_tama_attribute_metadata(line, meta);
-    }
     Ok(parsed)
 }
 
@@ -1568,46 +1564,6 @@ fn tama_metadata_key_supported(key: &str) -> bool {
     )
 }
 
-fn apply_tama_attribute_metadata(line: &str, meta: &mut ObligationMeta) {
-    if line.contains("tama.obligation") {
-        meta.tagged = true;
-    }
-    if line.contains("tama.helper") {
-        meta.tagged = true;
-        meta.kind = Some(ObligationKind::Helper);
-    }
-    if line.contains("tama.invariant") {
-        meta.tagged = true;
-        meta.kind = Some(ObligationKind::Invariant);
-    }
-    if let Some(rest) = line.split("tama.postcondition").nth(1) {
-        meta.tagged = true;
-        meta.kind = Some(ObligationKind::Postcondition);
-        if let Some(function) = rest
-            .split([']', ','])
-            .next()
-            .and_then(|value| value.split_whitespace().next())
-            .filter(|value| !value.is_empty())
-        {
-            meta.function = Some(function.rsplit('.').next().unwrap_or(function).to_string());
-        }
-    }
-    if line.contains("tama.mirror") {
-        if let Some(path) = first_quoted_value(line) {
-            meta.coverage.disposition = CoverageDisposition::Mirror;
-            meta.coverage.path = Some(path);
-            meta.coverage.reason = None;
-        }
-    }
-    if line.contains("tama.proof_only") {
-        if let Some(reason) = first_quoted_value(line) {
-            meta.coverage.disposition = CoverageDisposition::ProofOnly;
-            meta.coverage.path = None;
-            meta.coverage.reason = Some(reason);
-        }
-    }
-}
-
 fn parse_key_values(raw: &str) -> std::collections::BTreeMap<String, String> {
     let mut values = std::collections::BTreeMap::new();
     let mut chars = raw.trim().chars().peekable();
@@ -1662,12 +1618,6 @@ fn parse_key_values(raw: &str) -> std::collections::BTreeMap<String, String> {
         values.insert(key, value);
     }
     values
-}
-
-fn first_quoted_value(line: &str) -> Option<String> {
-    let (_, rest) = line.split_once('"')?;
-    let (value, _) = rest.split_once('"')?;
-    Some(value.to_string())
 }
 
 fn strip_lean_block_comments(text: &str) -> String {
@@ -2441,7 +2391,7 @@ theorem increment_post : True := by
 theorem postcondition_with_invariant_mirror : True := by
   trivial
 
-@[tama.helper]
+-- tama: kind=helper
 lemma arithmetic_helper : True := by
   trivial
 

--- a/docs/reference/SPEC.md
+++ b/docs/reference/SPEC.md
@@ -85,7 +85,7 @@ For a contract `Foo`:
 
 The Lean filenames intentionally avoid dotted suffixes like `Foo.spec.lean`. Dots in Lean module names map to path separators, so the flat convention uses `FooSpec.lean` and `FooProof.lean` instead.
 
-Inside `FooSpec.lean`, invariants are marked with an attribute such as `@[tama.invariant]`. Per-function obligations are marked with attributes that let Tama distinguish public contract obligations from helper lemmas.
+`FooSpec.lean` is plain Lean — Tama's coverage tracking happens on the proof side, so spec defs don't need any `-- tama:` markers. Use sections or docstrings to organize invariants and per-function postconditions.
 
 Example shape:
 
@@ -96,14 +96,12 @@ namespace FooSpec
 
 section Invariants
 
-@[tama.invariant]
 def totalSupply_nonnegative := ...
 
 end Invariants
 
 section Functions
 
-@[tama.postcondition Foo.transfer]
 def transfer_preserves_totalSupply := ...
 
 end Functions
@@ -111,7 +109,7 @@ end Functions
 end FooSpec
 ```
 
-`FooProof.lean` imports `FooSpec.lean` and contains proof obligations. Helper lemmas may exist freely, but only obligations marked as public contract obligations participate in mirror-test coverage.
+`FooProof.lean` imports `FooSpec.lean` and contains proof obligations. Each obligation theorem is preceded by a `-- tama: obligation ...` comment that tells Tama how to classify and cover it. Helper lemmas may exist freely; only obligations marked as public contract obligations participate in mirror-test coverage.
 
 ---
 
@@ -605,7 +603,7 @@ This should also be a Rust semantic port of the upstream Verity storage-layout s
 
 Checks that every public contract obligation has a mirror classification.
 
-Coverage is not over every theorem in `verity/proof/`. Helper lemmas are not obligations. Proof-only facts may be intentionally non-executable. Public contract obligations must be explicitly marked with Tama attributes or `-- tama:` metadata comments and either:
+Coverage is not over every theorem in `verity/proof/`. Helper lemmas are not obligations. Proof-only facts may be intentionally non-executable. Public contract obligations must be explicitly marked with a `-- tama:` metadata comment on the line above the theorem, and either:
 
 - linked to a Foundry mirror test; or
 - marked proof-only with a reason.
@@ -620,27 +618,20 @@ tests may exist as smoke tests, but they do not satisfy mirror coverage.
 Example Lean shape:
 
 ```lean
-@[tama.obligation]
-@[tama.mirror "test/verity/ERC20Lite.t.sol:ERC20LiteTest.testFuzzTransferPreservesTotalSupply"]
+-- tama: obligation kind=postcondition function=transfer coverage=mirror path=test/verity/ERC20Lite.t.sol:ERC20LiteTest.testFuzzTransferPreservesTotalSupply
 theorem transfer_preserves_total_supply : ... := by
   ...
 
-@[tama.helper]
+-- tama: kind=helper
 theorem arithmetic_helper : ... := by
   ...
 
-@[tama.proof_only "quantifies over symbolic state; no executable mirror"]
+-- tama: obligation coverage=proof_only reason="quantifies over symbolic state; no executable mirror"
 theorem symbolic_refinement : ... := by
   ...
 ```
 
-The comment form exists for projects that have not loaded no-op Tama Lean attributes yet:
-
-```lean
--- tama: obligation kind=postcondition function=transfer coverage=mirror path=test/verity/ERC20Lite.t.sol:ERC20LiteTest.testFuzzTransferPreservesTotalSupply
-theorem transfer_post : ... := by
-  ...
-```
+Recognized keys: `obligation` (marker, no value), `kind` (`helper` | `invariant` | `postcondition`), `function` (Verity function name), `coverage` (`mirror` | `proof_only` | `none`), `path` (mirror test path of the form `test/.../File.t.sol:Contract.testFuzzFoo`), `reason` (proof-only justification, quoted). Unknown keys are a build-time error.
 
 #### `structure`
 

--- a/site/src/pages/concepts.mdx
+++ b/site/src/pages/concepts.mdx
@@ -80,17 +80,18 @@ elaborates all three.
 ### Obligation
 
 A **public contract obligation** is a theorem in the proof file marked
-with `@[tama.obligation]`. Tama treats it as part of the contract's
-public surface: it must be either covered by a Foundry mirror test or
-explicitly marked proof-only with a stated reason. Helper lemmas are
-*not* obligations — they're internal scaffolding.
+with a `-- tama: obligation` comment on the line above. Tama treats it
+as part of the contract's public surface: it must be either covered by
+a Foundry mirror test or explicitly marked proof-only with a stated
+reason. Helper lemmas are *not* obligations — they're internal scaffolding.
 
 ### Mirror test
 
 A Foundry test marked as the executable shadow of an obligation, via
-`@[tama.mirror "test/verity/Foo.t.sol:FooTest.invariant_…"]` on the
-theorem. The mirror function must be a fuzz test (`testFuzz*`) or a
-Foundry invariant (`invariant_*`) — not a one-shot example test.
+`coverage=mirror path=test/verity/Foo.t.sol:FooTest.invariant_…` on the
+theorem's `-- tama:` comment. The mirror function must be a fuzz test
+(`testFuzz*`) or a Foundry invariant (`invariant_*`) — not a one-shot
+example test.
 
 This is how a property and a fuzz test are bound together: the proof
 says "for all inputs, P holds"; the mirror exercises the same P on the

--- a/site/src/pages/guides/audits.mdx
+++ b/site/src/pages/guides/audits.mdx
@@ -112,10 +112,9 @@ storage-layout: error
 
 What it inspects:
 
-- Every theorem tagged `@[tama.obligation]` either has a
-  `@[tama.mirror "..."]` annotation that points at a valid Foundry
-  symbol, or is tagged `@[tama.proof_only "<reason>"]` with a non-empty
-  reason.
+- Every theorem tagged with a `-- tama: obligation` comment either
+  carries `coverage=mirror path=...` pointing at a valid Foundry symbol,
+  or `coverage=proof_only reason="<reason>"` with a non-empty reason.
 - Mirror paths exist under Foundry's configured test directory.
 - Mirror function names start with `testFuzz` or `invariant_`.
 - Mirror contract names match an actual Foundry test contract in the file.
@@ -141,7 +140,7 @@ coverage: error
 
 What it inspects:
 
-- For every `@[tama.obligation]` theorem, the closure of axioms,
+- For every `-- tama: obligation` theorem, the closure of axioms,
   unsafe declarations, and unresolved names that the proof transitively
   depends on (via Lean's `collectAxioms`).
 - Compiler trust-surface artifacts (`artifacts/trust-report.json`,

--- a/site/src/pages/guides/foundry.mdx
+++ b/site/src/pages/guides/foundry.mdx
@@ -81,8 +81,9 @@ reads the manifest. For inspecting plain Solidity contracts, use
 
 A mirror test is just a Foundry test under `test/verity/`. It imports
 the generated `Iface` and `Deployer` and exercises the real Verity
-bytecode. The `@[tama.mirror "..."]` annotation in the proof file is
-the metadata link — `forge test` does not need to know about it.
+bytecode. The `coverage=mirror path=...` segment of the proof file's
+`-- tama:` comment is the metadata link — `forge test` does not need to
+know about it.
 
 ```solidity
 import {TipJarIface} from "src/generated/verity/TipJarIface.sol";

--- a/site/src/pages/guides/proofs.mdx
+++ b/site/src/pages/guides/proofs.mdx
@@ -10,51 +10,48 @@ import Callout from "../../components/Callout.astro";
 ## What counts as an obligation
 
 A **public contract obligation** is a theorem that part of your contract's
-contract-with-the-world depends on. In Verity terms: anything tagged
-`@[tama.obligation]` in `verity/proof/<Contract>Proof.lean`.
+contract-with-the-world depends on. In Verity terms: any theorem in
+`verity/proof/<Contract>Proof.lean` that has a `-- tama: obligation`
+comment on the line directly above it.
 
 `tama audit coverage` requires every public obligation to be either:
 
 - **mirrored** by a Foundry fuzz or invariant test, or
-- explicitly marked `@[tama.proof_only "<reason>"]` with a non-empty reason.
+- explicitly marked `coverage=proof_only reason="<reason>"` with a non-empty reason.
 
 Helper lemmas are *not* obligations and are not coverage-tracked. Mark
-them `@[tama.helper]` to be explicit, or just leave them untagged.
+them `-- tama: kind=helper` to be explicit, or just leave them untagged.
 
 ## A repeatable shape
 
-For each contract, the spec file usually has three kinds of statements:
+For each contract, the spec file usually has two kinds of statements:
 
 1. **Invariants** — properties of the storage that hold between calls.
 2. **Per-function postconditions** — what is true after a successful call.
-3. **Frame conditions** — which storage slots a function may have changed.
+
+The spec file is plain Lean — Tama's coverage tracking happens on the
+proof side, so spec defs don't need any `-- tama:` markers:
 
 ```lean
 namespace FooSpec
 
-@[tama.invariant]
 def total_in_range (s : Foo.State) : Prop :=
   s.total ≤ s.cap
 
-@[tama.postcondition Foo.mint]
 def mint_increases_total
     (pre post : Foo.State) (call : Foo.Call) : Prop :=
   post.total = pre.total + call.amount
 
-@[tama.frame Foo.mint]
-def mint_only_touches_balances : FrameSet := ⟨{ "balances", "total" }⟩
-
 end FooSpec
 ```
 
-Then in the proof file, prove that each function preserves each
-invariant, and that each call's postcondition follows from its inputs:
+In the proof file, prove that each function preserves each invariant,
+and tag each obligation theorem with a `-- tama:` metadata comment:
 
 ```lean
 namespace FooProof
 
-@[tama.obligation]
-@[tama.mirror "test/verity/Foo.t.sol:FooTest.invariant_totalInRange"]
+-- tama: obligation kind=invariant function=mint coverage=mirror path=test/verity/Foo.t.sol:FooTest.invariant_totalInRange
 theorem mint_preserves_total_in_range
     (pre : Foo.State) (call : Foo.Call)
     (h : FooSpec.total_in_range pre)
@@ -66,9 +63,14 @@ theorem mint_preserves_total_in_range
 end FooProof
 ```
 
+The keys are: `obligation` (marks the theorem as a public obligation),
+`kind=helper|invariant|postcondition`, `function=<name>`,
+`coverage=mirror|proof_only|none`, `path=<mirror path>`, and
+`reason="<text>"` for proof-only obligations.
+
 ## Mirror tests, in detail
 
-Every `@[tama.mirror "path:Symbol"]` annotation must point at:
+Every `coverage=mirror path=<path>:<symbol>` value must point at:
 
 - a file under Foundry's configured test directory (typically `test/`),
 - a contract-qualified Foundry symbol,
@@ -81,8 +83,7 @@ exercise the same universal statement the proof made, on real bytecode,
 under random inputs.
 
 ```lean
-@[tama.obligation]
-@[tama.mirror "test/verity/Foo.t.sol:FooTest.testFuzz_mintIncreasesTotal"]
+-- tama: obligation kind=postcondition function=mint coverage=mirror path=test/verity/Foo.t.sol:FooTest.testFuzz_mintIncreasesTotal
 theorem mint_increases_total : ... := by ...
 ```
 
@@ -102,8 +103,7 @@ useful executable shadow — for instance, "the storage encoding is
 collision-free for any pair of distinct mapping keys." Mark these:
 
 ```lean
-@[tama.obligation]
-@[tama.proof_only "quantifies over all key pairs; no concrete fuzz schedule covers it"]
+-- tama: obligation coverage=proof_only reason="quantifies over all key pairs; no concrete fuzz schedule covers it"
 theorem mapping_encoding_collision_free : ... := by ...
 ```
 
@@ -119,7 +119,7 @@ The intent: keep working contracts in a half-proven state during
 development; gate releases on a real proof.
 
 ```lean
-@[tama.obligation]
+-- tama: obligation kind=postcondition function=withdraw coverage=mirror path=test/verity/Foo.t.sol:FooTest.testFuzz_withdraw
 theorem withdraw_drops_total : ... := by
   sorry  -- ok locally, will fail audit
 ```
@@ -128,7 +128,7 @@ theorem withdraw_drops_total : ... := by
 There is no `tama.toml` switch to permit `sorryAx`. The audit is hard-coded
 to deny it. If a release CI is failing because an obligation hasn't been
 discharged, the answer is to discharge it (or mark it
-`@[tama.proof_only "..."]` with a real reason), not to bypass the gate.
+`coverage=proof_only reason="..."` with a real reason), not to bypass the gate.
 </Callout>
 
 ## Allowlisted axioms

--- a/site/src/pages/limitations.mdx
+++ b/site/src/pages/limitations.mdx
@@ -71,7 +71,7 @@ language exposes as the framework moves forward.
 These are accepted at build time but rejected by `tama audit` so they
 can't reach a release:
 
-- `sorry` in any `@[tama.obligation]` theorem.
+- `sorry` in any `-- tama: obligation` theorem.
 - Axioms not listed in `[trust.allow_axioms]`.
 - Raw event emission gaps where the manifest expects events.
 - Low-level `call` / `delegatecall` / proxy mechanics.

--- a/site/src/pages/reference/artifacts.mdx
+++ b/site/src/pages/reference/artifacts.mdx
@@ -87,7 +87,7 @@ Two complementary inputs feed `tama audit trust-boundary`:
 
 - `artifacts/trust-probe/axioms.json` (schema `tama.trust-probe.v1`)
   — the closure of axioms, unsafe declarations, and unresolved names
-  reachable from each `@[tama.obligation]` theorem, computed via
+  reachable from each `-- tama: obligation` theorem, computed via
   Lean's `collectAxioms`.
 - `artifacts/trust-report.json` and `artifacts/assumption-report.json`
   — Verity compiler outputs that localize unsupported or partially

--- a/site/src/pages/reference/manifest.mdx
+++ b/site/src/pages/reference/manifest.mdx
@@ -168,7 +168,7 @@ full build.
 
 ### `obligations`
 
-One entry per `@[tama.obligation]` theorem.
+One entry per `-- tama: obligation` theorem.
 
 | Field          | Meaning                                                        |
 | -------------- | -------------------------------------------------------------- |

--- a/site/src/pages/start.mdx
+++ b/site/src/pages/start.mdx
@@ -126,18 +126,15 @@ import TipJar
 namespace TipJarSpec
 
 /-- The recorded `total` is always the sum of every balance. -/
-@[tama.invariant]
 def total_tracks_balances (s : TipJar.State) : Prop :=
   s.total = s.balances.sumValues
 
 /-- After `deposit`, total grows by exactly `msg.value`. -/
-@[tama.postcondition TipJar.deposit]
 def deposit_increases_total
     (pre post : TipJar.State) (call : TipJar.Call) : Prop :=
   post.total = pre.total + call.value
 
 /-- After `withdraw`, total drops by exactly `amount`. -/
-@[tama.postcondition TipJar.withdraw]
 def withdraw_decreases_total
     (pre post : TipJar.State) (amount : UInt256) : Prop :=
   post.total = pre.total - amount
@@ -147,8 +144,9 @@ end TipJarSpec
 
 Three statements. The first is an **invariant** — a property the contract
 must preserve through every call. The next two are **postconditions** —
-properties of individual functions. Each is tagged with a `@[tama.…]`
-attribute so Tama knows to enforce coverage for it.
+properties of individual functions. The proof file (next step) is where
+Tama-visible markers go: each theorem proving one of these properties
+gets a `-- tama:` comment that tells Tama to enforce coverage for it.
 
 <Callout kind="proof" title="Why bother writing this down?">
 This is the contract's *intent* in the strongest possible form. Every test
@@ -165,8 +163,7 @@ import TipJarSpec
 
 namespace TipJarProof
 
-@[tama.obligation]
-@[tama.mirror "test/verity/TipJar.t.sol:TipJarTest.invariant_totalTracksBalances"]
+-- tama: obligation kind=invariant function=deposit coverage=mirror path=test/verity/TipJar.t.sol:TipJarTest.invariant_totalTracksBalances
 theorem deposit_preserves_invariant
     (pre : TipJar.State) (call : TipJar.Call)
     (h : TipJarSpec.total_tracks_balances pre) :
@@ -174,8 +171,7 @@ theorem deposit_preserves_invariant
   simp [TipJarSpec.total_tracks_balances, TipJar.deposit,
         Mapping.sumValues_update_add]
 
-@[tama.obligation]
-@[tama.mirror "test/verity/TipJar.t.sol:TipJarTest.invariant_totalTracksBalances"]
+-- tama: obligation kind=invariant function=withdraw coverage=mirror path=test/verity/TipJar.t.sol:TipJarTest.invariant_totalTracksBalances
 theorem withdraw_preserves_invariant
     (pre : TipJar.State) (amount : UInt256)
     (h : TipJarSpec.total_tracks_balances pre)
@@ -194,9 +190,10 @@ library takes care of the mapping arithmetic.
 [Verity's debugging-proofs guide](https://veritylang.com/guides/debugging-proofs)
 catalogues the tactics and error messages you'll meet most often.
 
-The two `@[tama.mirror "..."]` annotations point at a Foundry test
-we'll write next. This is what links a proven property to an executable
-fuzz test that exercises the same property on the real bytecode.
+The `coverage=mirror path=...` segment of each comment points at a
+Foundry test we'll write next. This is what links a proven property to
+an executable fuzz test that exercises the same property on the real
+bytecode.
 
 ## Step 5 — Write the mirror test
 
@@ -286,10 +283,10 @@ audit:
 ```
 
 The line that matters most is the last one. `trust-boundary` walks the
-Lean dependency graph of every theorem you tagged with `@[tama.obligation]`
-and refuses any reliance on `sorry` or unallowlisted axioms. That's the
-seal: the proofs are real, and they rest on a small set of named
-assumptions written down in `tama.toml`.
+Lean dependency graph of every theorem you tagged with a `-- tama: obligation`
+comment and refuses any reliance on `sorry` or unallowlisted axioms.
+That's the seal: the proofs are real, and they rest on a small set of
+named assumptions written down in `tama.toml`.
 
 ## Step 8 — Watch the audit catch a bug
 


### PR DESCRIPTION
The website docs and SPEC promoted `@[tama.invariant]`, `@[tama.obligation]`,
etc. as the primary form, with `-- tama:` framed as a fallback. In practice
the attribute form required Lean attribute definitions that no starter project
ships, while `-- tama:` is what `tama new` generates and what every fixture
uses. Worse, the Rust-side attribute parser was substring-based
(`line.contains("tama.helper")`), so it would mis-tag any line that happened
to contain that substring.

Collapse the two parallel surfaces into one:

- Delete `apply_tama_attribute_metadata` and its `first_quoted_value` helper;
  remove the `if line.contains("tama.")` branch from `parse_obligation_metadata`.
- Convert the `@[tama.helper]` line in the obligation-extraction test to
  `-- tama: kind=helper`.
- Rewrite all `@[tama.*]` examples and prose in site/start.mdx, concepts.mdx,
  guides/{audits,proofs,foundry}.mdx, reference/{manifest,artifacts}.mdx,
  limitations.mdx, and docs/reference/SPEC.md to use the comment form.

This removes the need for a `Tama.Attributes` Lean module / Lake dependency
and aligns the docs with what the starter and parser actually do.