### PR TITLE
Lift manifest caption above pipeline phase titles

### DIFF
--- a/site/src/components/PipelineDiagram.astro
+++ b/site/src/components/PipelineDiagram.astro
@@ -84,7 +84,7 @@
       stroke="rgba(31, 95, 79, 0.25)"
       stroke-dasharray="2 4"
     />
-    <text x="430" y="84" text-anchor="middle" class="caption">manifest — single source of truth</text>
+    <text x="430" y="68" text-anchor="middle" class="caption">manifest — single source of truth</text>
 
     <!-- Audit branches -->
     <g class="audit">


### PR DESCRIPTION
The caption sat at y=84, which collided with the phase-title row at
y=88 (Yul, Bytecode); horizontally the centred caption overlapped both
titles. Move it to y=68 — the empty band between the SOURCE/ARTIFACT
step labels (y=44) and the phase titles — so the slab is still labelled
without crossing other text.