### PR TITLE
Expand ERC20Lite starter: ownership transfer + access-control specs

### DIFF
--- a/crates/tama-project/src/lib.rs
+++ b/crates/tama-project/src/lib.rs
@@ -601,6 +601,12 @@ verity_contract ERC20Lite where
   -- proof obligation pair below shows both halves of access control: the
   -- authorized path actually rotates the slot, and the unauthorized path
   -- leaves it untouched.
+  --
+  -- This starter intentionally does NOT reject `newOwner = 0`. A
+  -- production Ownable contract would add a `require (newOwner != 0)
+  -- "..."` check (and a corresponding `transferOwnership_rejects_zero`
+  -- spec); we keep the starter minimal so the access-control
+  -- demonstration stays focused on one property at a time.
   function transferOwnership (newOwner : Address) : Unit := do
     let sender ← msgSender
     let currentOwner ← getStorageAddr ownerSlot
@@ -621,7 +627,7 @@ open Verity.EVM.Uint256
 -- Discharging it in the proof file binds an obligation to the implementation;
 -- mirroring it in a Foundry test ties the same obligation to the compiled
 -- bytecode. The collection here is intentionally varied so the starter shows
--- five common shapes:
+-- four common shapes:
 --   1. View / read-only specs   — `balanceOf_spec`, `totalSupply_spec`, `owner_spec`
 --   2. Frame conditions          — `mint_owner_preserved`, `transfer_total_supply_preserved`,
 --                                  `transferOwnership_supply_preserved`,
@@ -630,7 +636,6 @@ open Verity.EVM.Uint256
 --                                  `transfer_balances_effect`
 --   4. Negative access control   — `mint_unauthorized_no_change`,
 --                                  `transferOwnership_unauthorized_owner_unchanged`
---   5. Conservation              — `transfer_total_supply_preserved`
 
 /-! ## Frame conditions
 Properties of the form `s'.X = s.X` — the function does not touch part of state. -/
@@ -672,15 +677,18 @@ def transferOwnership_authorized_sets_owner
 -- that does `balance[sender] -= amount; balance[recipient] += amount` reads
 -- a stale `balance[recipient]` after the debit, which can mint or burn
 -- value when sender = recipient. The spec explicitly demands that the
--- balance be left untouched in that branch — which the `if sender == toAddr
--- then pure ()` short-circuit in the contract is what makes true. The
--- non-self branch additionally requires that crediting the recipient does
--- not overflow Uint256, and pins down the exact debit and credit.
+-- *entire balance mapping* be left untouched in that branch — full mapping
+-- equality, not just the sender's slot, so a faulty implementation that
+-- happened to leave sender alone but corrupted some other balance would
+-- still fail proof. The `if sender == toAddr then pure ()` short-circuit
+-- in the contract is what makes that true. The non-self branch
+-- additionally requires that crediting the recipient does not overflow
+-- Uint256, and pins down the exact debit and credit.
 def transfer_balances_effect
     (toAddr : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
   amount.val ≤ (s.storageMap 1 s.sender).val →
     (s.sender = toAddr →
-      s'.storageMap 1 s.sender = s.storageMap 1 s.sender) ∧
+      s'.storageMap = s.storageMap) ∧
     (s.sender ≠ toAddr →
       (s.storageMap 1 toAddr).val + amount.val ≤ Verity.Stdlib.Math.MAX_UINT256 →
         s'.storageMap 1 s.sender = (s.storageMap 1 s.sender) - amount ∧
@@ -948,7 +956,11 @@ contract ERC20LiteTest is Test {
     }
 
     // Negative access control mirror: non-owner mint reverts and leaves both
-    // totalSupply and the recipient balance unchanged.
+    // totalSupply and the recipient balance unchanged. The revert is
+    // matched against the exact `Error(string)` selector + message so a
+    // failure on a different code path (out-of-gas, an unrelated check, …)
+    // would surface as a test failure rather than pass under a generic
+    // `vm.expectRevert()`.
     // tama: mirrors=mint_unauthorized_no_change
     function testFuzzMintRevertsForNonOwner(address attacker, address account, uint256 rawAmount) public {
         vm.assume(attacker != address(this));
@@ -957,7 +969,7 @@ contract ERC20LiteTest is Test {
         uint256 supplyBefore = token.totalSupply();
         uint256 balanceBefore = token.balanceOf(account);
         vm.prank(attacker);
-        vm.expectRevert();
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "Caller is not the owner"));
         token.mint(account, amount);
         require(token.totalSupply() == supplyBefore, "supply unchanged");
         require(token.balanceOf(account) == balanceBefore, "balance unchanged");
@@ -1007,24 +1019,40 @@ contract ERC20LiteTest is Test {
         }
     }
 
-    // Authorized-path mirror: the current owner can promote a successor and
-    // `owner()` then reads back the new address.
+    // Authorized-path mirror: the current owner can promote a successor,
+    // `owner()` then reads back the new address, AND the previous owner has
+    // truly lost access — a `transferOwnership` from the previous owner
+    // after the rotation must revert. The second half catches a "copies
+    // instead of moves" bug class: an implementation that wrote to the new
+    // owner slot without invalidating the old owner's authority would pass
+    // the `owner()` read but fail the post-rotation revert check.
     // tama: mirrors=transferOwnership_authorized_sets_owner
     function testFuzzTransferOwnershipChangesOwner(address newOwner) public {
         ERC20LiteIface token = deployToken();
+        address oldOwner = address(this);
         token.transferOwnership(newOwner);
         require(token.owner() == newOwner, "owner rotated");
+        if (newOwner != oldOwner) {
+            vm.prank(oldOwner);
+            vm.expectRevert(abi.encodeWithSignature("Error(string)", "Caller is not the owner"));
+            token.transferOwnership(address(0xDEAD));
+            require(token.owner() == newOwner, "old owner cannot regain access");
+        }
     }
 
     // Negative access control mirror: a non-owner cannot transfer ownership
-    // and the slot is untouched after the revert.
+    // and the slot is untouched after the revert. The expected revert is
+    // matched against the exact `Error(string)` selector + message so a
+    // future change that started reverting for a different reason (gas, a
+    // new check, …) would surface as a test failure rather than slip
+    // through under a generic `vm.expectRevert()`.
     // tama: mirrors=transferOwnership_unauthorized_owner_unchanged
     function testFuzzTransferOwnershipRevertsForNonOwner(address attacker, address newOwner) public {
         vm.assume(attacker != address(this));
         ERC20LiteIface token = deployToken();
         address ownerBefore = token.owner();
         vm.prank(attacker);
-        vm.expectRevert();
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "Caller is not the owner"));
         token.transferOwnership(newOwner);
         require(token.owner() == ownerBefore, "owner unchanged");
     }

--- a/crates/tama-project/src/lib.rs
+++ b/crates/tama-project/src/lib.rs
@@ -597,6 +597,16 @@ verity_contract ERC20Lite where
     let currentOwner ← getStorageAddr ownerSlot
     return currentOwner
 
+  -- Ownership transfer: only the current owner can promote a successor. The
+  -- proof obligation pair below shows both halves of access control: the
+  -- authorized path actually rotates the slot, and the unauthorized path
+  -- leaves it untouched.
+  function transferOwnership (newOwner : Address) : Unit := do
+    let sender ← msgSender
+    let currentOwner ← getStorageAddr ownerSlot
+    require (sender == currentOwner) "Caller is not the owner"
+    setStorageAddr ownerSlot newOwner
+
 end src
 "#;
 
@@ -607,11 +617,38 @@ namespace spec.ERC20LiteSpec
 open Verity
 open Verity.EVM.Uint256
 
+-- Each definition below is a `Prop` over (input, pre-state, post-state, …).
+-- Discharging it in the proof file binds an obligation to the implementation;
+-- mirroring it in a Foundry test ties the same obligation to the compiled
+-- bytecode. The collection here is intentionally varied so the starter shows
+-- five common shapes:
+--   1. View / read-only specs   — `balanceOf_spec`, `totalSupply_spec`, `owner_spec`
+--   2. Frame conditions          — `mint_owner_preserved`, `transfer_total_supply_preserved`,
+--                                  `transferOwnership_supply_preserved`,
+--                                  `transferOwnership_balances_preserved`
+--   3. Authorized-path effects   — `transferOwnership_authorized_sets_owner`,
+--                                  `transfer_balances_effect`
+--   4. Negative access control   — `mint_unauthorized_no_change`,
+--                                  `transferOwnership_unauthorized_owner_unchanged`
+--   5. Conservation              — `transfer_total_supply_preserved`
+
+/-! ## Frame conditions
+Properties of the form `s'.X = s.X` — the function does not touch part of state. -/
+
 def transfer_total_supply_preserved (s s' : ContractState) : Prop :=
   s'.storage 2 = s.storage 2
 
 def mint_owner_preserved (s s' : ContractState) : Prop :=
   s'.storageAddr 0 = s.storageAddr 0
+
+def transferOwnership_supply_preserved (s s' : ContractState) : Prop :=
+  s'.storage 2 = s.storage 2
+
+def transferOwnership_balances_preserved (account : Address) (s s' : ContractState) : Prop :=
+  s'.storageMap 1 account = s.storageMap 1 account
+
+/-! ## Read-only specs
+Pure queries that return storage and leave state alone. -/
 
 def balanceOf_spec (account : Address) (result : Uint256) (s : ContractState) : Prop :=
   result = s.storageMap 1 account
@@ -621,6 +658,49 @@ def totalSupply_spec (result : Uint256) (s : ContractState) : Prop :=
 
 def owner_spec (result : Address) (s : ContractState) : Prop :=
   result = s.storageAddr 0
+
+/-! ## Authorized-path effects
+Capturing what an authorized caller observes after a successful state write. -/
+
+def transferOwnership_authorized_sets_owner
+    (newOwner : Address) (s s' : ContractState) : Prop :=
+  s.sender = s.storageAddr 0 → s'.storageAddr 0 = newOwner
+
+-- Successful-path arithmetic for `transfer`. The single shared precondition
+-- is "sender has enough balance"; the body splits on whether sender equals
+-- recipient. Self-transfer is the well-known footgun: a naive implementation
+-- that does `balance[sender] -= amount; balance[recipient] += amount` reads
+-- a stale `balance[recipient]` after the debit, which can mint or burn
+-- value when sender = recipient. The spec explicitly demands that the
+-- balance be left untouched in that branch — which the `if sender == toAddr
+-- then pure ()` short-circuit in the contract is what makes true. The
+-- non-self branch additionally requires that crediting the recipient does
+-- not overflow Uint256, and pins down the exact debit and credit.
+def transfer_balances_effect
+    (toAddr : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
+  amount.val ≤ (s.storageMap 1 s.sender).val →
+    (s.sender = toAddr →
+      s'.storageMap 1 s.sender = s.storageMap 1 s.sender) ∧
+    (s.sender ≠ toAddr →
+      (s.storageMap 1 toAddr).val + amount.val ≤ Verity.Stdlib.Math.MAX_UINT256 →
+        s'.storageMap 1 s.sender = (s.storageMap 1 s.sender) - amount ∧
+        s'.storageMap 1 toAddr = (s.storageMap 1 toAddr) + amount)
+
+/-! ## Negative access control
+The half of access control that says "non-owners cannot move state at all".
+Together with the authorized-path effect this is the full access-control story
+for `transferOwnership`; for `mint` it captures the security property that
+unauthorized callers leave totalSupply and the recipient's balance untouched. -/
+
+def mint_unauthorized_no_change
+    (toAddr : Address) (_amount : Uint256) (s s' : ContractState) : Prop :=
+  s.sender ≠ s.storageAddr 0 →
+    s'.storage 2 = s.storage 2 ∧
+    s'.storageMap 1 toAddr = s.storageMap 1 toAddr
+
+def transferOwnership_unauthorized_owner_unchanged
+    (s s' : ContractState) : Prop :=
+  s.sender ≠ s.storageAddr 0 → s'.storageAddr 0 = s.storageAddr 0
 
 end spec.ERC20LiteSpec
 "#;
@@ -677,6 +757,47 @@ theorem transfer_total_supply_preserved_after_run (toAddr : Address) (amount : U
   · simp [transfer, balancesSlot, msgSender, getMapping, Contract.run, ContractResult.snd,
       Verity.bind, Bind.bind, Verity.require, h_balance]
 
+-- Successful-path effect for `transfer`. The proof case-splits on
+-- self-transfer to discharge the spec's two branches: in the self-transfer
+-- branch the contract takes the `pure ()` shortcut and the storageMap is
+-- untouched; in the non-self branch the simp set unfolds `safeAdd` under
+-- `h_not_overflow_strict` and the if-then-else inside the storageMap
+-- closure resolves to `sub` and the recipient credit. The `show` step in
+-- the sender debit goal rewrites `s' - amount` into the `sub s'` form that
+-- `setMapping` literally produces — they are definitionally equal via the
+-- HSub instance, but simp on `+` fires `add_comm` while `sub` is left
+-- alone, so the two sides need to be brought into the same shape by hand.
+-- tama: discharges=transfer_balances_effect
+theorem transfer_balances_effect_after_run
+    (toAddr : Address) (amount : Uint256) (s : ContractState) :
+  transfer_balances_effect toAddr amount s ((transfer toAddr amount).run s).snd := by
+  unfold transfer_balances_effect
+  intro h_balance
+  refine ⟨?_, ?_⟩
+  · -- Self-transfer branch: `pure ()` shortcut leaves the balance unchanged.
+    -- `subst` rewrites `toAddr` to `s.sender` everywhere so `h_balance`
+    -- discharges the `senderBalance >= amount` require directly.
+    intro h_eq
+    subst h_eq
+    simp [transfer, balancesSlot, msgSender, getMapping,
+      Contract.run, ContractResult.snd, Verity.bind, Bind.bind, Verity.pure, Pure.pure,
+      Verity.require, h_balance]
+  · -- Non-self branch: full debit/credit under no-overflow.
+    intro h_ne h_no_overflow
+    have h_not_overflow_strict :
+        ¬ Verity.Stdlib.Math.MAX_UINT256 < (s.storageMap 1 toAddr).val + amount.val := by omega
+    refine ⟨?_, ?_⟩
+    · show ((transfer toAddr amount).run s).snd.storageMap 1 s.sender =
+        sub (s.storageMap 1 s.sender) amount
+      simp [transfer, balancesSlot, msgSender, getMapping, setMapping,
+        Contract.run, ContractResult.snd, Verity.bind, Bind.bind, Verity.pure, Pure.pure,
+        Verity.require, Verity.Stdlib.Math.requireSomeUint, Verity.Stdlib.Math.safeAdd,
+        h_balance, h_ne, h_not_overflow_strict]
+    · simp [transfer, balancesSlot, msgSender, getMapping, setMapping,
+        Contract.run, ContractResult.snd, Verity.bind, Bind.bind, Verity.pure, Pure.pure,
+        Verity.require, Verity.Stdlib.Math.requireSomeUint, Verity.Stdlib.Math.safeAdd,
+        h_balance, h_ne, h_not_overflow_strict]
+
 -- tama: discharges=balanceOf_spec
 theorem balanceOf_returns_storage_balance (account : Address) (s : ContractState) :
   let result := ((balanceOf account).run s).fst
@@ -695,6 +816,78 @@ theorem owner_returns_storage_owner (s : ContractState) :
   owner_spec result s := by
   simp [owner_spec, owner, ownerSlot, Bind.bind, Pure.pure]
 
+-- Negative access control: when the caller is not the owner, `mint` reverts,
+-- and a revert carries the original state unchanged. Specs whose body is an
+-- implication are stated without `let s'` so `intro` reaches the antecedent
+-- directly (a `let` binder would otherwise be the first thing introduced).
+-- tama: discharges=mint_unauthorized_no_change
+theorem mint_unauthorized_no_change_after_run
+    (toAddr : Address) (amount : Uint256) (s : ContractState) :
+  mint_unauthorized_no_change toAddr amount s ((mint toAddr amount).run s).snd := by
+  unfold mint_unauthorized_no_change
+  intro h_not_owner
+  refine ⟨?_, ?_⟩ <;>
+    simp [mint, ownerSlot, msgSender, getStorageAddr, Contract.run, ContractResult.snd,
+      Verity.bind, Bind.bind, Verity.require, h_not_owner]
+
+-- Authorized-path effect: when sender = owner, `transferOwnership` writes the
+-- new owner into slot 0. The single-branch proof is the simplest shape — no
+-- case split, just unfold and let `setStorageAddr` rewrite the slot.
+-- tama: discharges=transferOwnership_authorized_sets_owner
+theorem transferOwnership_authorized_sets_owner_after_run
+    (newOwner : Address) (s : ContractState) :
+  transferOwnership_authorized_sets_owner newOwner s
+    ((transferOwnership newOwner).run s).snd := by
+  unfold transferOwnership_authorized_sets_owner
+  intro h_owner
+  simp [transferOwnership, ownerSlot, msgSender, getStorageAddr, setStorageAddr,
+    Contract.run, ContractResult.snd, Verity.bind, Bind.bind,
+    Verity.require, h_owner]
+
+-- Negative access control: a non-owner caller leaves slot 0 untouched.
+-- tama: discharges=transferOwnership_unauthorized_owner_unchanged
+theorem transferOwnership_unauthorized_owner_unchanged_after_run
+    (newOwner : Address) (s : ContractState) :
+  transferOwnership_unauthorized_owner_unchanged s
+    ((transferOwnership newOwner).run s).snd := by
+  unfold transferOwnership_unauthorized_owner_unchanged
+  intro h_not_owner
+  simp [transferOwnership, ownerSlot, msgSender, getStorageAddr,
+    Contract.run, ContractResult.snd, Verity.bind, Bind.bind,
+    Verity.require, h_not_owner]
+
+-- Frame condition: `transferOwnership` never touches the totalSupply slot.
+-- The proof case-splits on authorization so the same statement covers both
+-- branches — the authorized branch does write a slot, just not slot 2.
+-- tama: discharges=transferOwnership_supply_preserved
+theorem transferOwnership_supply_preserved_after_run
+    (newOwner : Address) (s : ContractState) :
+  let s' := ((transferOwnership newOwner).run s).snd
+  transferOwnership_supply_preserved s s' := by
+  unfold transferOwnership_supply_preserved
+  by_cases h_owner : s.sender = s.storageAddr 0
+  · simp [transferOwnership, ownerSlot, msgSender, getStorageAddr, setStorageAddr,
+      Contract.run, ContractResult.snd, Verity.bind, Bind.bind,
+      Verity.require, h_owner]
+  · simp [transferOwnership, ownerSlot, msgSender, getStorageAddr,
+      Contract.run, ContractResult.snd, Verity.bind, Bind.bind,
+      Verity.require, h_owner]
+
+-- Frame condition: `transferOwnership` never touches the balances mapping.
+-- tama: discharges=transferOwnership_balances_preserved
+theorem transferOwnership_balances_preserved_after_run
+    (account : Address) (newOwner : Address) (s : ContractState) :
+  let s' := ((transferOwnership newOwner).run s).snd
+  transferOwnership_balances_preserved account s s' := by
+  unfold transferOwnership_balances_preserved
+  by_cases h_owner : s.sender = s.storageAddr 0
+  · simp [transferOwnership, ownerSlot, msgSender, getStorageAddr,
+      setStorageAddr, Contract.run, ContractResult.snd, Verity.bind, Bind.bind,
+      Verity.require, h_owner]
+  · simp [transferOwnership, ownerSlot, msgSender, getStorageAddr,
+      Contract.run, ContractResult.snd, Verity.bind, Bind.bind,
+      Verity.require, h_owner]
+
 end proof.ERC20LiteProof
 "#;
 
@@ -703,12 +896,17 @@ pragma solidity ^0.8.20;
 
 import {ERC20LiteDeployer} from "../../src/generated/verity/ERC20LiteDeployer.sol";
 import {ERC20LiteIface} from "../../src/generated/verity/ERC20LiteIface.sol";
-import {StdInvariant} from "forge-std/StdInvariant.sol";
+import {Test} from "forge-std/Test.sol";
 
 // These Foundry tests mirror the proof obligations in
 // verity/proof/ERC20LiteProof.lean. Run `tama build` first so the generated
 // deployer contains bytecode compiled from the Verity/Yul pipeline.
-contract ERC20LiteTest is StdInvariant {
+//
+// `Test` (from forge-std) provides the `vm` cheatcode entry point, which we
+// use below to exercise the negative access-control path with `vm.prank` and
+// `vm.expectRevert`. It also inherits from `StdInvariant`, so the invariant
+// handler harness still works.
+contract ERC20LiteTest is Test {
     ERC20LiteIface internal invariantToken;
     uint256 internal invariantMinted;
 
@@ -749,6 +947,22 @@ contract ERC20LiteTest is StdInvariant {
         require(token.owner() == address(this), "owner preserved");
     }
 
+    // Negative access control mirror: non-owner mint reverts and leaves both
+    // totalSupply and the recipient balance unchanged.
+    // tama: mirrors=mint_unauthorized_no_change
+    function testFuzzMintRevertsForNonOwner(address attacker, address account, uint256 rawAmount) public {
+        vm.assume(attacker != address(this));
+        ERC20LiteIface token = deployToken();
+        uint256 amount = rawAmount % 1e36;
+        uint256 supplyBefore = token.totalSupply();
+        uint256 balanceBefore = token.balanceOf(account);
+        vm.prank(attacker);
+        vm.expectRevert();
+        token.mint(account, amount);
+        require(token.totalSupply() == supplyBefore, "supply unchanged");
+        require(token.balanceOf(account) == balanceBefore, "balance unchanged");
+    }
+
     // Transfer mirror: moving tokens changes balances but preserves supply.
     // tama: mirrors=transfer_total_supply_preserved
     function testFuzzTransferPreservesTotalSupply(address recipient, uint256 rawMint, uint256 rawTransfer) public {
@@ -764,6 +978,74 @@ contract ERC20LiteTest is StdInvariant {
             require(token.balanceOf(recipient) == amount, "recipient balance");
         }
         require(token.totalSupply() == minted, "supply preserved");
+    }
+
+    // Transfer effect mirror: covers both branches the spec splits on.
+    // The non-self branch debits the sender by `amount` and credits the
+    // recipient by `amount`. The self-transfer branch leaves the balance
+    // unchanged — the spec demands this explicitly because a naive
+    // `balance[a] -= n; balance[b] += n` (without the `if a == b` guard)
+    // reads a stale recipient balance after the debit, which has been a
+    // recurring source of token-implementation bugs.
+    // tama: mirrors=transfer_balances_effect
+    function testFuzzTransferDebitAndCredit(address recipient, uint256 rawMint, uint256 rawTransfer) public {
+        ERC20LiteIface token = deployToken();
+        uint256 minted = rawMint % 1e36;
+        uint256 amount = minted == 0 ? 0 : rawTransfer % (minted + 1);
+        require(token.mint(address(this), minted), "mint");
+        uint256 senderBefore = token.balanceOf(address(this));
+        uint256 recipientBefore = token.balanceOf(recipient);
+        require(senderBefore >= amount, "precondition: balance");
+        require(token.transfer(recipient, amount), "transfer");
+        if (recipient == address(this)) {
+            // Self-transfer: balance unchanged.
+            require(token.balanceOf(address(this)) == senderBefore, "self balance preserved");
+        } else {
+            require(recipientBefore + amount >= recipientBefore, "precondition: no overflow");
+            require(token.balanceOf(address(this)) == senderBefore - amount, "sender debit");
+            require(token.balanceOf(recipient) == recipientBefore + amount, "recipient credit");
+        }
+    }
+
+    // Authorized-path mirror: the current owner can promote a successor and
+    // `owner()` then reads back the new address.
+    // tama: mirrors=transferOwnership_authorized_sets_owner
+    function testFuzzTransferOwnershipChangesOwner(address newOwner) public {
+        ERC20LiteIface token = deployToken();
+        token.transferOwnership(newOwner);
+        require(token.owner() == newOwner, "owner rotated");
+    }
+
+    // Negative access control mirror: a non-owner cannot transfer ownership
+    // and the slot is untouched after the revert.
+    // tama: mirrors=transferOwnership_unauthorized_owner_unchanged
+    function testFuzzTransferOwnershipRevertsForNonOwner(address attacker, address newOwner) public {
+        vm.assume(attacker != address(this));
+        ERC20LiteIface token = deployToken();
+        address ownerBefore = token.owner();
+        vm.prank(attacker);
+        vm.expectRevert();
+        token.transferOwnership(newOwner);
+        require(token.owner() == ownerBefore, "owner unchanged");
+    }
+
+    // Frame mirror: rotating the owner does not move tokens. Both authorized
+    // and unauthorized paths must hold the totalSupply and an account balance
+    // constant; the proof case-splits on authorization for the same reason.
+    // tama: mirrors=transferOwnership_supply_preserved,transferOwnership_balances_preserved
+    function testFuzzTransferOwnershipPreservesTokenState(
+        address newOwner,
+        address holder,
+        uint256 rawMint
+    ) public {
+        ERC20LiteIface token = deployToken();
+        uint256 minted = rawMint % 1e36;
+        require(token.mint(holder, minted), "mint");
+        uint256 supplyBefore = token.totalSupply();
+        uint256 balanceBefore = token.balanceOf(holder);
+        token.transferOwnership(newOwner);
+        require(token.totalSupply() == supplyBefore, "supply preserved");
+        require(token.balanceOf(holder) == balanceBefore, "balance preserved");
     }
 
     // tama: mirrors=balanceOf_spec
@@ -835,6 +1117,7 @@ pragma solidity ^0.8.20;
 interface ERC20LiteIface {
     function mint(address to, uint256 amount) external returns (bool);
     function transfer(address to, uint256 amount) external returns (bool);
+    function transferOwnership(address newOwner) external;
     function balanceOf(address account) external view returns (uint256);
     function totalSupply() external view returns (uint256);
     function owner() external view returns (address);
@@ -964,8 +1247,15 @@ metadata_bytecode_hash = "none"
         assert!(!proof.contains("kind="));
         assert!(!proof.contains("coverage="));
         assert!(proof.contains("tama: discharges=transfer_total_supply_preserved"));
+        assert!(proof.contains("tama: discharges=transfer_balances_effect"));
+        assert!(proof.contains("tama: discharges=mint_unauthorized_no_change"));
+        assert!(proof.contains("tama: discharges=transferOwnership_authorized_sets_owner"));
+        assert!(proof.contains("tama: discharges=transferOwnership_unauthorized_owner_unchanged"));
+        assert!(proof.contains("tama: discharges=transferOwnership_supply_preserved"));
+        assert!(proof.contains("tama: discharges=transferOwnership_balances_preserved"));
         assert!(proof.contains("((transfer toAddr amount).run s).snd"));
         assert!(proof.contains("((mint toAddr amount).run s).snd"));
+        assert!(proof.contains("((transferOwnership newOwner).run s).snd"));
         assert!(proof.contains("((balanceOf account).run s).fst"));
         let test = read_to_string(&root.join("test/verity/ERC20Lite.t.sol")).unwrap();
         assert!(!test.contains("testTransferPostPlaceholder"));
@@ -974,11 +1264,27 @@ metadata_bytecode_hash = "none"
         assert!(test.contains("ERC20LiteDeployer.deploy(initialOwner)"));
         assert!(test.contains("// tama: mirrors=owner_spec"));
         assert!(test.contains("// tama: mirrors=transfer_total_supply_preserved"));
+        assert!(test.contains("// tama: mirrors=transfer_balances_effect"));
+        assert!(test.contains("// tama: mirrors=mint_unauthorized_no_change"));
+        assert!(test.contains("// tama: mirrors=transferOwnership_authorized_sets_owner"));
+        assert!(test.contains("// tama: mirrors=transferOwnership_unauthorized_owner_unchanged"));
+        assert!(test.contains(
+            "// tama: mirrors=transferOwnership_supply_preserved,transferOwnership_balances_preserved"
+        ));
         assert!(test.contains("function testFuzzDeploymentSetsOwner(address initialOwner)"));
         assert!(test.contains("testFuzzTransferPreservesTotalSupply"));
-        assert!(test.contains("StdInvariant"));
+        assert!(test.contains("function testFuzzTransferDebitAndCredit("));
+        assert!(test.contains("function testFuzzMintRevertsForNonOwner("));
+        assert!(test.contains("function testFuzzTransferOwnershipChangesOwner("));
+        assert!(test.contains("function testFuzzTransferOwnershipRevertsForNonOwner("));
+        assert!(test.contains("function testFuzzTransferOwnershipPreservesTokenState("));
+        assert!(test.contains("vm.prank(attacker)"));
+        assert!(test.contains("vm.expectRevert()"));
+        assert!(test.contains("import {Test} from \"forge-std/Test.sol\""));
+        assert!(test.contains("contract ERC20LiteTest is Test"));
         assert!(test.contains("invariant_totalSupplyTracksMinted"));
         assert!(test.contains("token.transfer(recipient, amount)"));
+        assert!(test.contains("token.transferOwnership(newOwner)"));
         assert!(test.contains("These Foundry tests mirror the proof obligations"));
         let script = read_to_string(&root.join("script/ERC20Lite.s.sol")).unwrap();
         assert!(script.contains("contract DeployERC20Lite is Script"));
@@ -989,10 +1295,19 @@ metadata_bytecode_hash = "none"
         assert!(source.contains("This starter is intentionally small"));
         assert!(source.contains("Storage slots are explicit"));
         assert!(source.contains("function view balanceOf"));
+        assert!(source.contains("function transferOwnership (newOwner : Address)"));
         assert!(!source.contains(r#"emit "Transfer""#));
         let spec = read_to_string(&root.join("verity/spec/ERC20LiteSpec.lean")).unwrap();
         assert!(spec.contains("def transfer_total_supply_preserved"));
+        assert!(spec.contains("def transfer_balances_effect"));
+        assert!(spec.contains("def mint_unauthorized_no_change"));
+        assert!(spec.contains("def transferOwnership_authorized_sets_owner"));
+        assert!(spec.contains("def transferOwnership_unauthorized_owner_unchanged"));
+        assert!(spec.contains("def transferOwnership_supply_preserved"));
+        assert!(spec.contains("def transferOwnership_balances_preserved"));
         assert!(!spec.contains("-- tama:"));
+        let iface = read_to_string(&root.join("src/generated/verity/ERC20LiteIface.sol")).unwrap();
+        assert!(iface.contains("function transferOwnership(address newOwner) external"));
         let starter_readme = read_to_string(&root.join("docs/README.md")).unwrap();
         assert!(starter_readme.contains("script/ERC20Lite.s.sol:DeployERC20Lite"));
         assert!(starter_readme.contains("ERC20LITE_OWNER"));

--- a/site/src/pages/guides/starter.mdx
+++ b/site/src/pages/guides/starter.mdx
@@ -73,6 +73,12 @@ verity_contract ERC20Lite where
       setMapping balancesSlot toAddr newRecipientBalance
     return true
 
+  function transferOwnership (newOwner : Address) : Unit := do
+    let sender ← msgSender
+    let currentOwner ← getStorageAddr ownerSlot
+    require (sender == currentOwner) "Caller is not the owner"
+    setStorageAddr ownerSlot newOwner
+
   function view balanceOf  (addr : Address) : Uint256 := ...
   function view totalSupply ()              : Uint256 := ...
   function view owner       ()              : Address := ...
@@ -95,6 +101,12 @@ would double-count when `from == to`. The branch handles that case
 explicitly — partly for correctness, partly because the proof has to walk
 through both halves of the `if`.
 
+**`transferOwnership` is the access-control half of mint.** `mint`
+guards behind `sender == owner`; `transferOwnership` guards behind the
+same predicate and rotates that owner to a successor. The pair gives
+the spec file two access-control obligations to demonstrate (one for
+each function, with both halves — authorized and unauthorized).
+
 ## The specification
 
 `verity/spec/ERC20LiteSpec.lean` is **pure Lean** — no `-- tama:`
@@ -107,12 +119,21 @@ import ERC20Lite
 
 namespace ERC20LiteSpec
 
+-- Frame conditions: parts of state the function never touches.
 def transfer_total_supply_preserved (s s' : ContractState) : Prop :=
   s'.storage 2 = s.storage 2
 
 def mint_owner_preserved (s s' : ContractState) : Prop :=
   s'.storageAddr 0 = s.storageAddr 0
 
+def transferOwnership_supply_preserved (s s' : ContractState) : Prop :=
+  s'.storage 2 = s.storage 2
+
+def transferOwnership_balances_preserved
+    (account : Address) (s s' : ContractState) : Prop :=
+  s'.storageMap 1 account = s.storageMap 1 account
+
+-- Read-only views: pure reads of storage.
 def balanceOf_spec (account : Address) (result : Uint256) (s : ContractState) : Prop :=
   result = s.storageMap 1 account
 
@@ -122,28 +143,68 @@ def totalSupply_spec (result : Uint256) (s : ContractState) : Prop :=
 def owner_spec (result : Address) (s : ContractState) : Prop :=
   result = s.storageAddr 0
 
+-- Authorized-path effects: what an authorized caller observes.
+def transferOwnership_authorized_sets_owner
+    (newOwner : Address) (s s' : ContractState) : Prop :=
+  s.sender = s.storageAddr 0 → s'.storageAddr 0 = newOwner
+
+def transfer_balances_effect
+    (toAddr : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
+  amount.val ≤ (s.storageMap 1 s.sender).val →
+    (s.sender = toAddr →
+      s'.storageMap 1 s.sender = s.storageMap 1 s.sender) ∧
+    (s.sender ≠ toAddr →
+      (s.storageMap 1 toAddr).val + amount.val ≤ Verity.Stdlib.Math.MAX_UINT256 →
+        s'.storageMap 1 s.sender = (s.storageMap 1 s.sender) - amount ∧
+        s'.storageMap 1 toAddr = (s.storageMap 1 toAddr) + amount)
+
+-- Negative access control: unauthorized callers leave state alone.
+def mint_unauthorized_no_change
+    (toAddr : Address) (_amount : Uint256) (s s' : ContractState) : Prop :=
+  s.sender ≠ s.storageAddr 0 →
+    s'.storage 2 = s.storage 2 ∧
+    s'.storageMap 1 toAddr = s.storageMap 1 toAddr
+
+def transferOwnership_unauthorized_owner_unchanged
+    (s s' : ContractState) : Prop :=
+  s.sender ≠ s.storageAddr 0 → s'.storageAddr 0 = s.storageAddr 0
+
 end ERC20LiteSpec
 ```
 
-Five properties:
+The set is grouped to show the five common shapes a starter should
+exercise:
 
-1. **`transfer` preserves total supply.** A token moves; nothing is
-   created or destroyed.
-2. **`mint` preserves the owner.** Only the owner can mint, and minting
-   doesn't change who the owner is.
-3. **`balanceOf` returns the storage balance.** The view is a faithful read.
-4. **`totalSupply` returns the storage supply.** Same shape.
-5. **`owner` returns the storage owner.** Same shape.
+1. **Frame conditions** — `transfer_total_supply_preserved`,
+   `mint_owner_preserved`, `transferOwnership_supply_preserved`,
+   `transferOwnership_balances_preserved`. The function does not touch
+   that part of state.
+2. **Read-only views** — `balanceOf_spec`, `totalSupply_spec`,
+   `owner_spec`. The query is a faithful read.
+3. **Authorized-path effects** —
+   `transferOwnership_authorized_sets_owner` pins down what the owner
+   observes after a successful rotation; `transfer_balances_effect`
+   pins down the exact debit and credit on the success path, and
+   *demands the self-transfer branch leaves the balance untouched* —
+   the well-known double-debit footgun gets a first-class proof
+   obligation, not a comment.
+4. **Negative access control** — `mint_unauthorized_no_change`,
+   `transferOwnership_unauthorized_owner_unchanged`. The
+   complementary half of access control: not only does the authorized
+   path do the right thing, the unauthorized path does *nothing*. This
+   is the property that prevents a non-owner from minting tokens or
+   stealing the contract.
+5. **Conservation** — `transfer_total_supply_preserved` doubles as
+   the conservation law: a token moves; nothing is created or destroyed.
 
-Three are facts about views (they read what they say). Two are facts
-about state transitions. For a teaching contract this is the small core;
-a richer ERC20 spec would add monotonicity of total supply under mint,
-balance arithmetic under transfer, and so on.
+Four are facts about pure reads. The rest are facts about state
+transitions — split between "what changes" (effects) and "what doesn't
+change" (frames and revert-on-unauthorized).
 
 ## The proofs
 
 `verity/proof/ERC20LiteProof.lean` discharges each spec definition. The
-transfer proof is the most interesting:
+transfer-supply proof is the most case-splitty:
 
 ```lean
 -- tama: discharges=transfer_total_supply_preserved
@@ -162,28 +223,55 @@ theorem transfer_total_supply_preserved_after_run
   · simp [transfer, ..., h_balance]
 ```
 
-Two case splits drive the proof: *did the sender have enough balance?*
+Two case splits drive that proof: *did the sender have enough balance?*
 and *is the recipient the same as the sender?* That's a proof shape
 worth recognizing — one branch per `require`, one branch per non-trivial
 `if`. The `simp` invocations unfold the contract definitions and rely
 on the Verity standard library for the storage and arithmetic lemmas.
 
+The implication-shaped specs (effects and negative access control)
+take a slightly different shape. They drop the `let s' := ...` binder
+because `intro` would otherwise consume it before reaching the
+implication's antecedent, and they `intro` the precondition before
+discharging the conjunction:
+
+```lean
+-- tama: discharges=transferOwnership_authorized_sets_owner
+theorem transferOwnership_authorized_sets_owner_after_run
+    (newOwner : Address) (s : ContractState) :
+    transferOwnership_authorized_sets_owner newOwner s
+      ((transferOwnership newOwner).run s).snd := by
+  unfold transferOwnership_authorized_sets_owner
+  intro h_owner
+  simp [transferOwnership, ownerSlot, msgSender, getStorageAddr,
+    setStorageAddr, Contract.run, ContractResult.snd, Verity.bind,
+    Bind.bind, Verity.require, h_owner]
+```
+
+The `transfer_balances_effect` proof is the most elaborate of the new
+ones: it case-splits on `s.sender = toAddr` to handle the spec's two
+branches separately, uses `subst` in the self-transfer branch so the
+balance precondition lines up after the substitution, and ends with a
+`show` step that rewrites the `s' - amount` form into the `sub s'`
+form `setMapping` literally produces. (The two are definitionally
+equal via the `HSub` instance, but `simp`'s `add_comm` fires on `+`
+while leaving `sub` alone, so the sender side has to be canonicalized
+by hand.)
+
 The model is symmetric. The spec file declares an obligation by
-defining `transfer_total_supply_preserved`. The proof claims it with
+defining `transfer_total_supply_preserved`; the proof claims it with
 `-- tama: discharges=transfer_total_supply_preserved` directly above
-the theorem. The Foundry test mirrors it with a matching
+the theorem; the Foundry test mirrors it with a matching
 `// tama: mirrors=transfer_total_supply_preserved` (next section).
 Theorems and `lemma`s without a `discharges=` tag are silently treated
-as helpers; the four other obligations —
-`mint_preserves_owner_after_run`, `balanceOf_returns_storage_balance`,
-`totalSupply_returns_storage_supply`, `owner_returns_storage_owner` —
-each carry their own `discharges=` tag pointing at the matching spec
-def, and each spec is mirrored by a corresponding `testFuzz_*` function
-in the Foundry test file.
+as helpers; the ten other obligations each carry their own
+`discharges=` tag pointing at the matching spec def, and each spec is
+mirrored by at least one `testFuzz_*` (or `invariant_*`) function in
+the Foundry test file.
 
 ## The mirror tests
 
-`test/verity/ERC20Lite.t.sol` does two things.
+`test/verity/ERC20Lite.t.sol` does three things.
 
 **One. Property-shaped fuzz tests.** Each obligation has a `testFuzz_*`
 function that exercises the same property on the real bytecode, with a
@@ -211,7 +299,33 @@ the deployed bytecode are about the same contract, they agree. If a
 bridge regeneration drifts, the fuzz test catches it before audit even
 runs.
 
-**Two. A Foundry stateful invariant.** A handler calls `mint` and
+**Two. Negative access-control tests with `vm.prank` /
+`vm.expectRevert`.** The unauthorized-path specs are mirrored by tests
+that impersonate a non-owner and assert the call reverts and the slot
+is untouched:
+
+```solidity
+// tama: mirrors=transferOwnership_unauthorized_owner_unchanged
+function testFuzzTransferOwnershipRevertsForNonOwner(
+    address attacker, address newOwner
+) public {
+    vm.assume(attacker != address(this));
+    ERC20LiteIface token = deployToken();
+    address ownerBefore = token.owner();
+    vm.prank(attacker);
+    vm.expectRevert();
+    token.transferOwnership(newOwner);
+    require(token.owner() == ownerBefore, "owner unchanged");
+}
+```
+
+Two pieces of state are checked: the call reverts (via `expectRevert`),
+and the storage slot is unchanged after the revert. A would-be exploit
+that bypassed the require would either not revert (caught by
+`expectRevert`) or modify state across the revert (caught by the
+post-call read).
+
+**Three. A Foundry stateful invariant.** A handler calls `mint` and
 `transfer` with random parameters across a long stateful run, while
 `invariant_totalSupplyTracksMinted` checks the global property at every
 step:
@@ -245,18 +359,18 @@ tama build
 tama audit
 ```
 
-You should see five obligations covered:
+You should see eleven obligations covered:
 
 ```text
 audit:
   ✓ structure       artifacts present, hashes match
-  ✓ selectors       5 functions agree across Verity / manifest / Yul / Solidity
+  ✓ selectors       6 functions agree across Verity / manifest / Yul / Solidity
   ✓ storage-layout  3 slots, no overlap
   ✓ coverage        every spec has a discharger and a mirror
   ✓ trust-boundary  no sorry, axioms allowlisted
 ```
 
-Five functions, three storage slots, five obligations all mirrored.
+Six functions, three storage slots, eleven obligations all mirrored.
 The whole pipeline you just toured is sealed end-to-end.
 
 ## Where to go next

--- a/site/src/pages/guides/starter.mdx
+++ b/site/src/pages/guides/starter.mdx
@@ -172,32 +172,32 @@ def transferOwnership_unauthorized_owner_unchanged
 end ERC20LiteSpec
 ```
 
-The set is grouped to show the five common shapes a starter should
+The set is grouped to show the four common shapes a starter should
 exercise:
 
 1. **Frame conditions** — `transfer_total_supply_preserved`,
    `mint_owner_preserved`, `transferOwnership_supply_preserved`,
    `transferOwnership_balances_preserved`. The function does not touch
-   that part of state.
+   that part of state. `transfer_total_supply_preserved` is also the
+   contract's conservation law: a token moves, nothing is created or
+   destroyed.
 2. **Read-only views** — `balanceOf_spec`, `totalSupply_spec`,
    `owner_spec`. The query is a faithful read.
 3. **Authorized-path effects** —
    `transferOwnership_authorized_sets_owner` pins down what the owner
    observes after a successful rotation; `transfer_balances_effect`
    pins down the exact debit and credit on the success path, and
-   *demands the self-transfer branch leaves the balance untouched* —
-   the well-known double-debit footgun gets a first-class proof
-   obligation, not a comment.
+   *demands the self-transfer branch leaves the entire balance mapping
+   untouched* — the well-known double-debit footgun gets a first-class
+   proof obligation, not a comment.
 4. **Negative access control** — `mint_unauthorized_no_change`,
    `transferOwnership_unauthorized_owner_unchanged`. The
    complementary half of access control: not only does the authorized
    path do the right thing, the unauthorized path does *nothing*. This
    is the property that prevents a non-owner from minting tokens or
    stealing the contract.
-5. **Conservation** — `transfer_total_supply_preserved` doubles as
-   the conservation law: a token moves; nothing is created or destroyed.
 
-Four are facts about pure reads. The rest are facts about state
+Three are facts about pure reads. The rest are facts about state
 transitions — split between "what changes" (effects) and "what doesn't
 change" (frames and revert-on-unauthorized).
 

--- a/site/src/pages/start.mdx
+++ b/site/src/pages/start.mdx
@@ -285,7 +285,7 @@ You should see the five checks pass:
 ```text
 audit:
   ✓ structure       all files present, bytecode hashes match
-  ✓ selectors       6 functions agree across Verity / manifest / Yul / Solidity
+  ✓ selectors       8 functions agree across Verity / manifest / Yul / Solidity
   ✓ storage-layout  no overlap, all encodings recognized
   ✓ coverage        every spec has a discharger and a mirror
   ✓ trust-boundary  no sorry, axioms allowlisted


### PR DESCRIPTION
## Summary

- Adds a `transferOwnership(newOwner)` function to the `tama init` ERC20Lite starter, with the same `sender == owner` guard `mint` already uses.
- Grows the spec/proof/test surface from 5 obligations to 11, grouped by **kind** so the starter shows off the common proof shapes a teaching contract should exercise: frame conditions, read-only views, authorized-path effects, conservation, and **negative access control** (the half that says "non-owners cannot move state at all").
- Adds a `transfer_balances_effect` spec that explicitly case-splits on self-transfer. The well-known footgun — naive `balance[a] -= n; balance[b] += n` reads a stale recipient balance when `a == b` — is now a first-class proof obligation, not a code comment.
- Updates `site/src/pages/guides/starter.mdx` (the line-by-line walkthrough) to match.

## What's new

| New spec | Kind | Why it matters |
|---|---|---|
| `transferOwnership_authorized_sets_owner` | Authorized-path effect | Owner can rotate ownership; `owner()` reads back the successor. |
| `transferOwnership_unauthorized_owner_unchanged` | Negative access control | Non-owner attempts revert and leave the slot untouched. |
| `transferOwnership_supply_preserved` | Frame condition | Ownership change does not move tokens. |
| `transferOwnership_balances_preserved` | Frame condition | Same, for any account balance. |
| `mint_unauthorized_no_change` | Negative access control | Non-owner mint reverts and leaves totalSupply / recipient balance unchanged. |
| `transfer_balances_effect` | Authorized-path effect | Self-transfer leaves balance unchanged; non-self debits sender by `amount` and credits recipient by `amount`. |

Each spec has a discharging Lean theorem (no `sorry`, no new axioms) and a Foundry mirror test. The two unauthorized-path tests use `vm.prank` + `vm.expectRevert` and additionally read the storage slot back to assert the revert was atomic.

## Verification

- `cargo test --workspace` — 285 tests pass.
- `tama init starter && cd starter && tama check && tama build && tama test && tama audit` — all five audit checks pass; 10 Foundry tests pass (was 5); Lean elaborates 11 proof theorems from a clean scaffold.
- `npx astro build` in `site/` — docs site builds clean.

## Test plan

- [ ] CI passes (`tama doctor`, `tama check`, `tama build --locked`, `tama test`, `tama audit`).
- [ ] Skim `site/src/pages/guides/starter.mdx` rendered output for prose flow with the new spec groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)