### PR TITLE
fix: avoid shallow forge-std init installs

### DIFF
--- a/crates/tama-cli/src/main.rs
+++ b/crates/tama-cli/src/main.rs
@@ -19,8 +19,8 @@ Creates a Foundry-compatible Verity starter. The starter includes commented
 ERC20Lite source/spec/proof files, mirror Foundry tests, generated bridge
 placeholders, and a deploy script that works after `tama build`.
 
-Online init also runs `lake update`, initializes Git when needed, installs the
-pinned forge-std dependency as a submodule, and refreshes tama.lock.
+Online init also runs `lake update`, initializes Git when needed, installs
+forge-std as a pinned submodule, and refreshes tama.lock.
 Use --offline to write files only and do dependency setup later.";
 const NEW_AFTER_HELP: &str = "\
 Adds one Verity contract scaffold under the configured source, spec, proof, and
@@ -2168,9 +2168,9 @@ fn forge_install_optional_flags() -> Result<Vec<&'static str>, String> {
 
 fn select_forge_install_optional_flags(help: &str) -> Vec<&'static str> {
     let mut flags = Vec::new();
-    if help.contains("--shallow") {
-        flags.push("--shallow");
-    }
+    // `forge install <repo>@<tag> --shallow` can clone the default branch
+    // without the requested tag, then fail tag checkout even when the tag
+    // exists upstream. Keep pinned installs reproducible and non-shallow.
     if help.contains("--no-commit") {
         flags.push("--no-commit");
     }
@@ -2184,7 +2184,7 @@ fn offline_init_instructions() -> [&'static str; 6] {
         "  when network access is available, run:",
         "  lake update",
         "  git init  # if this project is not already inside a Git worktree",
-        "  forge install foundry-rs/forge-std@v1.16.1 --shallow",
+        "  forge install foundry-rs/forge-std@v1.16.1",
     ]
 }
 
@@ -2788,7 +2788,8 @@ mod tests {
         assert!(instructions.contains("lake update"));
         assert!(instructions.contains("git init"));
         assert!(instructions.contains("TAMA_LAKE_PACKAGE_CACHE"));
-        assert!(instructions.contains("forge install foundry-rs/forge-std@v1.16.1 --shallow"));
+        assert!(instructions.contains("forge install foundry-rs/forge-std@v1.16.1"));
+        assert!(!instructions.contains("--shallow"));
         assert!(!instructions.contains("--no-git"));
     }
 
@@ -3109,11 +3110,11 @@ mod tests {
         );
         assert_eq!(
             select_forge_install_optional_flags("Options:\n      --shallow\n      --no-commit\n"),
-            vec!["--shallow", "--no-commit"]
+            vec!["--no-commit"]
         );
         assert_eq!(
             select_forge_install_optional_flags("Options:\n      --shallow\n"),
-            vec!["--shallow"]
+            Vec::<&'static str>::new()
         );
     }
 

--- a/docs/reference/SPEC.md
+++ b/docs/reference/SPEC.md
@@ -470,7 +470,7 @@ Steps:
 6. Write `lean-toolchain` pinned to the compatible Lean version.
 7. Create `verity/src`, `verity/spec`, `verity/proof`, `test/verity`, `src/generated/verity`.
 8. Generate the commented `ERC20Lite` starter across implementation, spec, proof, bridge, deploy script, manifest, and mirror test layers.
-9. Install pinned `forge-std` using Foundry as a git submodule. Tama may pass `--shallow` to reduce download size, but must not pass `--no-git`.
+9. Install pinned `forge-std` using Foundry as a git submodule. Tama must not pass `--no-git` or `--shallow`; shallow Forge installs can fail to check out pinned tags.
 10. Pin the Verity Lean dependency in `lakefile.toml` and `lake-manifest.json`.
 11. Print next steps.
 

--- a/site/src/pages/reference/cli.mdx
+++ b/site/src/pages/reference/cli.mdx
@@ -62,7 +62,7 @@ Writes `tama.toml`, `tama.lock`, `foundry.toml`, `lakefile.toml`,
 the commented `verity/src/`, `verity/spec/`, `verity/proof/` files,
 the `script/ERC20Lite.s.sol` deployment script, the Foundry mirror
 test, and the generated bridge paths. Installs `forge-std` as a
-shallow git submodule.
+pinned git submodule.
 
 The starter is a real Verity project — it builds and audits cleanly
 without hand edits.

--- a/site/src/pages/troubleshooting.mdx
+++ b/site/src/pages/troubleshooting.mdx
@@ -75,8 +75,8 @@ dirty, or at another revision under `.lake/packages`.
 
 ## Forge dependencies
 
-`tama init` installs pinned `forge-std` as a Git submodule, optionally
-shallow. For Solidity-side dependency changes, use Forge directly:
+`tama init` installs pinned `forge-std` as a Git submodule. For
+Solidity-side dependency changes, use Forge directly:
 
 ```sh
 forge install owner/repo


### PR DESCRIPTION
## Summary
- stop passing `--shallow` to the pinned `forge-std` install during `tama init`
- keep `forge-std@v1.16.1` pinned and update offline/docs guidance to match

## Tests
- `cargo test -p tama-cli`