### PR TITLE
ci: warm shared Lake package cache

### DIFF
--- a/.github/actions/install-toolchain/action.yml
+++ b/.github/actions/install-toolchain/action.yml
@@ -47,13 +47,13 @@ runs:
         exit 1
 
     - name: Install Foundry
-      if: inputs.install-foundry == 'true'
+      if: ${{ inputs.install-foundry == 'true' }}
       uses: foundry-rs/foundry-toolchain@v1.6.0
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
 
     - name: Install solc-select and solc 0.8.33 (in venv)
-      if: inputs.install-solc == 'true'
+      if: ${{ inputs.install-solc == 'true' }}
       shell: bash
       run: |
         set -euo pipefail

--- a/.github/actions/install-toolchain/action.yml
+++ b/.github/actions/install-toolchain/action.yml
@@ -1,4 +1,4 @@
-name: Install Lean, Foundry, and solc
+name: Install toolchain
 description: Install elan (Lean), Foundry, and solc 0.8.33 with retry-tolerant fetches.
 
 inputs:
@@ -6,6 +6,14 @@ inputs:
     description: Token used by foundryup to query the GitHub releases API. Avoids unauthenticated rate-limit 403s.
     required: false
     default: ${{ github.token }}
+  install-foundry:
+    description: Install Foundry.
+    required: false
+    default: "true"
+  install-solc:
+    description: Install solc-select and solc 0.8.33.
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -39,11 +47,13 @@ runs:
         exit 1
 
     - name: Install Foundry
+      if: inputs.install-foundry == 'true'
       uses: foundry-rs/foundry-toolchain@v1.6.0
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
 
     - name: Install solc-select and solc 0.8.33 (in venv)
+      if: inputs.install-solc == 'true'
       shell: bash
       run: |
         set -euo pipefail
@@ -61,5 +71,10 @@ runs:
     - name: Print toolchain versions
       shell: bash
       run: |
-        forge --version
-        solc --version
+        elan --version
+        if command -v forge >/dev/null 2>&1; then
+          forge --version
+        fi
+        if command -v solc >/dev/null 2>&1; then
+          solc --version
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,29 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/cache@v4
+      - name: Restore Lake package cache
+        id: tama-lake-cache
+        uses: actions/cache/restore@v4
         with:
           path: .cache/tama
-          key: tama-lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/lake-manifest.json') }}
+          key: tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/tama-project/src/lib.rs', 'crates/tama-project/src/templates/starter-lake-manifest.json', 'fixtures/projects/counter/lake-manifest.json', 'fixtures/projects/counter/lean-toolchain') }}
           restore-keys: |
-            tama-lake-${{ runner.os }}-${{ runner.arch }}-
+            tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-
+      - name: Lake cache diagnostics
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "cache-hit=${{ steps.tama-lake-cache.outputs.cache-hit }}"
+          found=0
+          for dir in .cache/tama/lake-packages/*/.lake/build; do
+            if [ -d "$dir" ]; then
+              found=1
+              du -sh "$dir"
+            fi
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "No cached Lake package builds found."
+          fi
       - uses: ./.github/actions/install-toolchain
       - name: Build Tama
         run: cargo build --workspace
@@ -137,12 +154,29 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/cache@v4
+      - name: Restore Lake package cache
+        id: tama-lake-cache
+        uses: actions/cache/restore@v4
         with:
           path: .cache/tama
-          key: tama-lake-negative-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/lake-manifest.json') }}
+          key: tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/tama-project/src/lib.rs', 'crates/tama-project/src/templates/starter-lake-manifest.json', 'fixtures/projects/counter/lake-manifest.json', 'fixtures/projects/counter/lean-toolchain') }}
           restore-keys: |
-            tama-lake-negative-${{ runner.os }}-${{ runner.arch }}-
+            tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-
+      - name: Lake cache diagnostics
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "cache-hit=${{ steps.tama-lake-cache.outputs.cache-hit }}"
+          found=0
+          for dir in .cache/tama/lake-packages/*/.lake/build; do
+            if [ -d "$dir" ]; then
+              found=1
+              du -sh "$dir"
+            fi
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "No cached Lake package builds found."
+          fi
       - uses: ./.github/actions/install-toolchain
       - name: Build Tama and starter baseline
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  TAMA_LAKE_CACHE_SCHEMA: tama-lake-v3
   TAMA_LAKE_PACKAGE_CACHE: ${{ github.workspace }}/.cache/tama/lake-packages
 
 jobs:
@@ -62,15 +63,16 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .cache/tama
-          key: tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/tama-project/src/lib.rs', 'crates/tama-project/src/templates/starter-lake-manifest.json', 'fixtures/projects/counter/lake-manifest.json', 'fixtures/projects/counter/lean-toolchain') }}
+          key: ${{ env.TAMA_LAKE_CACHE_SCHEMA }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/tama-project/src/starter_deps.rs', 'crates/tama-project/src/templates/starter-lake-manifest.json', 'fixtures/projects/counter/lake-manifest.json', 'fixtures/projects/counter/lean-toolchain') }}
           restore-keys: |
-            tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-
+            ${{ env.TAMA_LAKE_CACHE_SCHEMA }}-${{ runner.os }}-${{ runner.arch }}-
       - name: Lake cache diagnostics
         shell: bash
         run: |
           set -euo pipefail
           echo "cache-hit=${{ steps.tama-lake-cache.outputs.cache-hit }}"
           found=0
+          marker=0
           for dir in .cache/tama/lake-packages/*/.lake/build; do
             if [ -d "$dir" ]; then
               found=1
@@ -79,6 +81,16 @@ jobs:
           done
           if [ "$found" -eq 0 ]; then
             echo "No cached Lake package builds found."
+          fi
+          if [ -f .cache/tama/lake-cache-ready ]; then
+            marker=1
+            cat .cache/tama/lake-cache-ready
+          else
+            echo "No Lake cache readiness marker found."
+          fi
+          if [ "${{ steps.tama-lake-cache.outputs.cache-hit }}" = "true" ] && { [ "$found" -eq 0 ] || [ "$marker" -eq 0 ]; }; then
+            echo "::error::Exact Lake cache hit is missing compiled package builds or the readiness marker. Bump TAMA_LAKE_CACHE_SCHEMA or delete the cache entry."
+            exit 1
           fi
       - uses: ./.github/actions/install-toolchain
       - name: Build Tama
@@ -159,15 +171,16 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .cache/tama
-          key: tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/tama-project/src/lib.rs', 'crates/tama-project/src/templates/starter-lake-manifest.json', 'fixtures/projects/counter/lake-manifest.json', 'fixtures/projects/counter/lean-toolchain') }}
+          key: ${{ env.TAMA_LAKE_CACHE_SCHEMA }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/tama-project/src/starter_deps.rs', 'crates/tama-project/src/templates/starter-lake-manifest.json', 'fixtures/projects/counter/lake-manifest.json', 'fixtures/projects/counter/lean-toolchain') }}
           restore-keys: |
-            tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-
+            ${{ env.TAMA_LAKE_CACHE_SCHEMA }}-${{ runner.os }}-${{ runner.arch }}-
       - name: Lake cache diagnostics
         shell: bash
         run: |
           set -euo pipefail
           echo "cache-hit=${{ steps.tama-lake-cache.outputs.cache-hit }}"
           found=0
+          marker=0
           for dir in .cache/tama/lake-packages/*/.lake/build; do
             if [ -d "$dir" ]; then
               found=1
@@ -176,6 +189,16 @@ jobs:
           done
           if [ "$found" -eq 0 ]; then
             echo "No cached Lake package builds found."
+          fi
+          if [ -f .cache/tama/lake-cache-ready ]; then
+            marker=1
+            cat .cache/tama/lake-cache-ready
+          else
+            echo "No Lake cache readiness marker found."
+          fi
+          if [ "${{ steps.tama-lake-cache.outputs.cache-hit }}" = "true" ] && { [ "$found" -eq 0 ] || [ "$marker" -eq 0 ]; }; then
+            echo "::error::Exact Lake cache hit is missing compiled package builds or the readiness marker. Bump TAMA_LAKE_CACHE_SCHEMA or delete the cache entry."
+            exit 1
           fi
       - uses: ./.github/actions/install-toolchain
       - name: Build Tama and starter baseline

--- a/.github/workflows/lake-cache.yml
+++ b/.github/workflows/lake-cache.yml
@@ -21,6 +21,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  TAMA_LAKE_CACHE_SCHEMA: tama-lake-v3
   TAMA_LAKE_PACKAGE_CACHE: ${{ github.workspace }}/.cache/tama/lake-packages
 
 jobs:
@@ -42,15 +43,16 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .cache/tama
-          key: tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/tama-project/src/lib.rs', 'crates/tama-project/src/templates/starter-lake-manifest.json', 'fixtures/projects/counter/lake-manifest.json', 'fixtures/projects/counter/lean-toolchain') }}
+          key: ${{ env.TAMA_LAKE_CACHE_SCHEMA }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/tama-project/src/starter_deps.rs', 'crates/tama-project/src/templates/starter-lake-manifest.json', 'fixtures/projects/counter/lake-manifest.json', 'fixtures/projects/counter/lean-toolchain') }}
           restore-keys: |
-            tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-
+            ${{ env.TAMA_LAKE_CACHE_SCHEMA }}-${{ runner.os }}-${{ runner.arch }}-
       - name: Lake cache diagnostics after restore
         shell: bash
         run: |
           set -euo pipefail
           echo "cache-hit=${{ steps.tama-lake-cache.outputs.cache-hit }}"
           found=0
+          marker=0
           for dir in .cache/tama/lake-packages/*/.lake/build; do
             if [ -d "$dir" ]; then
               found=1
@@ -59,6 +61,16 @@ jobs:
           done
           if [ "$found" -eq 0 ]; then
             echo "No cached Lake package builds found."
+          fi
+          if [ -f .cache/tama/lake-cache-ready ]; then
+            marker=1
+            cat .cache/tama/lake-cache-ready
+          else
+            echo "No Lake cache readiness marker found."
+          fi
+          if [ "${{ steps.tama-lake-cache.outputs.cache-hit }}" = "true" ] && { [ "$found" -eq 0 ] || [ "$marker" -eq 0 ]; }; then
+            echo "::error::Exact Lake cache hit is missing compiled package builds or the readiness marker. Bump TAMA_LAKE_CACHE_SCHEMA or delete the cache entry."
+            exit 1
           fi
       - uses: dtolnay/rust-toolchain@stable
         if: steps.tama-lake-cache.outputs.cache-hit != 'true'
@@ -75,7 +87,8 @@ jobs:
           cargo build --workspace
           tmp="$(mktemp -d)"
           project="$tmp/cache-warm"
-          tama init "$project"
+          tama --offline init "$project"
+          tama --root "$project" update --no-forge
           tama --root "$project" build --no-solc --no-forge
       - name: Lake cache diagnostics after warmup
         shell: bash
@@ -92,6 +105,11 @@ jobs:
             echo "No cached Lake package builds found."
             exit 1
           fi
+          {
+            echo "schema=${{ env.TAMA_LAKE_CACHE_SCHEMA }}"
+            echo "key=${{ steps.tama-lake-cache.outputs.cache-primary-key }}"
+            echo "source=${{ github.workflow }} run ${{ github.run_id }}"
+          } > .cache/tama/lake-cache-ready
       - name: Save Lake package cache
         if: steps.tama-lake-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4

--- a/.github/workflows/lake-cache.yml
+++ b/.github/workflows/lake-cache.yml
@@ -1,0 +1,100 @@
+name: Lake Cache
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/lake-cache.yml"
+      - ".github/actions/install-toolchain/action.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/**"
+      - "fixtures/projects/counter/lake-manifest.json"
+      - "fixtures/projects/counter/lean-toolchain"
+  schedule:
+    - cron: "17 8 * * 1"
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  TAMA_LAKE_PACKAGE_CACHE: ${{ github.workspace }}/.cache/tama/lake-packages
+
+jobs:
+  warm:
+    name: Warm Lake cache ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux
+            os: ubuntu-22.04
+          - name: macos-arm64
+            os: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore Lake package cache
+        id: tama-lake-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .cache/tama
+          key: tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/tama-project/src/lib.rs', 'crates/tama-project/src/templates/starter-lake-manifest.json', 'fixtures/projects/counter/lake-manifest.json', 'fixtures/projects/counter/lean-toolchain') }}
+          restore-keys: |
+            tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-
+      - name: Lake cache diagnostics after restore
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "cache-hit=${{ steps.tama-lake-cache.outputs.cache-hit }}"
+          found=0
+          for dir in .cache/tama/lake-packages/*/.lake/build; do
+            if [ -d "$dir" ]; then
+              found=1
+              du -sh "$dir"
+            fi
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "No cached Lake package builds found."
+          fi
+      - uses: dtolnay/rust-toolchain@stable
+        if: steps.tama-lake-cache.outputs.cache-hit != 'true'
+      - uses: Swatinem/rust-cache@v2
+        if: steps.tama-lake-cache.outputs.cache-hit != 'true'
+      - uses: ./.github/actions/install-toolchain
+        if: steps.tama-lake-cache.outputs.cache-hit != 'true'
+      - name: Warm starter Lake package builds
+        if: steps.tama-lake-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          export PATH="$PWD/target/debug:$HOME/.elan/bin:$HOME/.foundry/bin:$HOME/.local/bin:$PATH"
+          cargo build --workspace
+          tmp="$(mktemp -d)"
+          project="$tmp/cache-warm"
+          tama init "$project"
+          tama --root "$project" build --no-solc --no-forge
+      - name: Lake cache diagnostics after warmup
+        shell: bash
+        run: |
+          set -euo pipefail
+          found=0
+          for dir in .cache/tama/lake-packages/*/.lake/build; do
+            if [ -d "$dir" ]; then
+              found=1
+              du -sh "$dir"
+            fi
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "No cached Lake package builds found."
+            exit 1
+          fi
+      - name: Save Lake package cache
+        if: steps.tama-lake-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .cache/tama
+          key: ${{ steps.tama-lake-cache.outputs.cache-primary-key }}

--- a/.github/workflows/lake-cache.yml
+++ b/.github/workflows/lake-cache.yml
@@ -78,6 +78,9 @@ jobs:
         if: steps.tama-lake-cache.outputs.cache-hit != 'true'
       - uses: ./.github/actions/install-toolchain
         if: steps.tama-lake-cache.outputs.cache-hit != 'true'
+        with:
+          install-foundry: "false"
+          install-solc: "false"
       - name: Warm starter Lake package builds
         if: steps.tama-lake-cache.outputs.cache-hit != 'true'
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  TAMA_LAKE_CACHE_SCHEMA: tama-lake-v3
   TAMA_LAKE_PACKAGE_CACHE: ${{ github.workspace }}/.cache/tama/lake-packages
 
 jobs:
@@ -61,15 +62,16 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .cache/tama
-          key: tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/tama-project/src/lib.rs', 'crates/tama-project/src/templates/starter-lake-manifest.json', 'fixtures/projects/counter/lake-manifest.json', 'fixtures/projects/counter/lean-toolchain') }}
+          key: ${{ env.TAMA_LAKE_CACHE_SCHEMA }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/tama-project/src/starter_deps.rs', 'crates/tama-project/src/templates/starter-lake-manifest.json', 'fixtures/projects/counter/lake-manifest.json', 'fixtures/projects/counter/lean-toolchain') }}
           restore-keys: |
-            tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-
+            ${{ env.TAMA_LAKE_CACHE_SCHEMA }}-${{ runner.os }}-${{ runner.arch }}-
       - name: Lake cache diagnostics
         shell: bash
         run: |
           set -euo pipefail
           echo "cache-hit=${{ steps.tama-lake-cache.outputs.cache-hit }}"
           found=0
+          marker=0
           for dir in .cache/tama/lake-packages/*/.lake/build; do
             if [ -d "$dir" ]; then
               found=1
@@ -78,6 +80,16 @@ jobs:
           done
           if [ "$found" -eq 0 ]; then
             echo "No cached Lake package builds found."
+          fi
+          if [ -f .cache/tama/lake-cache-ready ]; then
+            marker=1
+            cat .cache/tama/lake-cache-ready
+          else
+            echo "No Lake cache readiness marker found."
+          fi
+          if [ "${{ steps.tama-lake-cache.outputs.cache-hit }}" = "true" ] && { [ "$found" -eq 0 ] || [ "$marker" -eq 0 ]; }; then
+            echo "::error::Exact Lake cache hit is missing compiled package builds or the readiness marker. Bump TAMA_LAKE_CACHE_SCHEMA or delete the cache entry."
+            exit 1
           fi
       - uses: ./.github/actions/install-toolchain
       - name: Build Tama
@@ -132,6 +144,33 @@ jobs:
             tama --root "$counter" inspect Counter "$field" >/dev/null
             tama --root "$counter" --json inspect Counter "$field" | python3 -m json.tool >/dev/null
           done
+      - name: Mark Lake package cache ready
+        if: steps.tama-lake-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          found=0
+          for dir in .cache/tama/lake-packages/*/.lake/build; do
+            if [ -d "$dir" ]; then
+              found=1
+              du -sh "$dir"
+            fi
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "No cached Lake package builds found."
+            exit 1
+          fi
+          {
+            echo "schema=${{ env.TAMA_LAKE_CACHE_SCHEMA }}"
+            echo "key=${{ steps.tama-lake-cache.outputs.cache-primary-key }}"
+            echo "source=${{ github.workflow }} run ${{ github.run_id }}"
+          } > .cache/tama/lake-cache-ready
+      - name: Save Lake package cache
+        if: steps.tama-lake-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .cache/tama
+          key: ${{ steps.tama-lake-cache.outputs.cache-primary-key }}
 
   negative-audit:
     name: Release negative audit
@@ -146,15 +185,16 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .cache/tama
-          key: tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/tama-project/src/lib.rs', 'crates/tama-project/src/templates/starter-lake-manifest.json', 'fixtures/projects/counter/lake-manifest.json', 'fixtures/projects/counter/lean-toolchain') }}
+          key: ${{ env.TAMA_LAKE_CACHE_SCHEMA }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/tama-project/src/starter_deps.rs', 'crates/tama-project/src/templates/starter-lake-manifest.json', 'fixtures/projects/counter/lake-manifest.json', 'fixtures/projects/counter/lean-toolchain') }}
           restore-keys: |
-            tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-
+            ${{ env.TAMA_LAKE_CACHE_SCHEMA }}-${{ runner.os }}-${{ runner.arch }}-
       - name: Lake cache diagnostics
         shell: bash
         run: |
           set -euo pipefail
           echo "cache-hit=${{ steps.tama-lake-cache.outputs.cache-hit }}"
           found=0
+          marker=0
           for dir in .cache/tama/lake-packages/*/.lake/build; do
             if [ -d "$dir" ]; then
               found=1
@@ -163,6 +203,16 @@ jobs:
           done
           if [ "$found" -eq 0 ]; then
             echo "No cached Lake package builds found."
+          fi
+          if [ -f .cache/tama/lake-cache-ready ]; then
+            marker=1
+            cat .cache/tama/lake-cache-ready
+          else
+            echo "No Lake cache readiness marker found."
+          fi
+          if [ "${{ steps.tama-lake-cache.outputs.cache-hit }}" = "true" ] && { [ "$found" -eq 0 ] || [ "$marker" -eq 0 ]; }; then
+            echo "::error::Exact Lake cache hit is missing compiled package builds or the readiness marker. Bump TAMA_LAKE_CACHE_SCHEMA or delete the cache entry."
+            exit 1
           fi
       - uses: ./.github/actions/install-toolchain
       - name: Build baseline
@@ -355,7 +405,6 @@ jobs:
           json.dump(data, open(path, "w", encoding="utf-8"), indent=2)
           PY
           expect_audit_failure "$project" trust-boundary
-
   installer:
     name: Release installer safety
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,12 +56,29 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/cache@v4
+      - name: Restore Lake package cache
+        id: tama-lake-cache
+        uses: actions/cache/restore@v4
         with:
           path: .cache/tama
-          key: tama-lake-release-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/lake-manifest.json') }}
+          key: tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/tama-project/src/lib.rs', 'crates/tama-project/src/templates/starter-lake-manifest.json', 'fixtures/projects/counter/lake-manifest.json', 'fixtures/projects/counter/lean-toolchain') }}
           restore-keys: |
-            tama-lake-release-${{ runner.os }}-${{ runner.arch }}-
+            tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-
+      - name: Lake cache diagnostics
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "cache-hit=${{ steps.tama-lake-cache.outputs.cache-hit }}"
+          found=0
+          for dir in .cache/tama/lake-packages/*/.lake/build; do
+            if [ -d "$dir" ]; then
+              found=1
+              du -sh "$dir"
+            fi
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "No cached Lake package builds found."
+          fi
       - uses: ./.github/actions/install-toolchain
       - name: Build Tama
         run: cargo build --workspace --release
@@ -124,12 +141,29 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/cache@v4
+      - name: Restore Lake package cache
+        id: tama-lake-cache
+        uses: actions/cache/restore@v4
         with:
           path: .cache/tama
-          key: tama-lake-release-negative-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/lake-manifest.json') }}
+          key: tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/tama-project/src/lib.rs', 'crates/tama-project/src/templates/starter-lake-manifest.json', 'fixtures/projects/counter/lake-manifest.json', 'fixtures/projects/counter/lean-toolchain') }}
           restore-keys: |
-            tama-lake-release-negative-${{ runner.os }}-${{ runner.arch }}-
+            tama-lake-v2-${{ runner.os }}-${{ runner.arch }}-
+      - name: Lake cache diagnostics
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "cache-hit=${{ steps.tama-lake-cache.outputs.cache-hit }}"
+          found=0
+          for dir in .cache/tama/lake-packages/*/.lake/build; do
+            if [ -d "$dir" ]; then
+              found=1
+              du -sh "$dir"
+            fi
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "No cached Lake package builds found."
+          fi
       - uses: ./.github/actions/install-toolchain
       - name: Build baseline
         shell: bash

--- a/crates/tama-project/src/lib.rs
+++ b/crates/tama-project/src/lib.rs
@@ -6,12 +6,11 @@ use tama_common::{read_to_string, write_string};
 use tama_config::{PathsConfig, TamaLock};
 use toml_edit::Item;
 
+mod starter_deps;
+use starter_deps::{DEFAULT_LEAN_TOOLCHAIN, DEFAULT_SOLC, DEFAULT_VERITY_GIT, DEFAULT_VERITY_REV};
+
 pub type Result<T> = std::result::Result<T, Error>;
 
-const DEFAULT_VERITY_GIT: &str = "https://github.com/lfglabs-dev/verity.git";
-const DEFAULT_VERITY_REV: &str = "9b0114efcc0af589af63dd3f2eafcdf1a24dbf1e";
-const DEFAULT_LEAN_TOOLCHAIN: &str = "leanprover/lean4:v4.22.0";
-const DEFAULT_SOLC: &str = "0.8.33";
 const STARTER_LAKE_MANIFEST: &str = include_str!("templates/starter-lake-manifest.json");
 const STARTER_CI_WORKFLOW: &str = include_str!("templates/starter-ci.yml");
 

--- a/crates/tama-project/src/starter_deps.rs
+++ b/crates/tama-project/src/starter_deps.rs
@@ -1,0 +1,4 @@
+pub(crate) const DEFAULT_VERITY_GIT: &str = "https://github.com/lfglabs-dev/verity.git";
+pub(crate) const DEFAULT_VERITY_REV: &str = "9b0114efcc0af589af63dd3f2eafcdf1a24dbf1e";
+pub(crate) const DEFAULT_LEAN_TOOLCHAIN: &str = "leanprover/lean4:v4.22.0";
+pub(crate) const DEFAULT_SOLC: &str = "0.8.33";


### PR DESCRIPTION
## Summary
- add a dedicated Lake Cache workflow on main/manual/schedule to warm compiled Lake package builds for Linux and macOS
- switch CI and release e2e/negative-audit jobs to restore the shared `tama-lake-v2` cache instead of saving PR/tag-local caches
- add cache diagnostics so logs show cache hits and restored `.lake/build` sizes

## Notes
- the first PR run for this change can still be cold because the shared main cache does not exist until the warmer runs on main
- after merge, run the Lake Cache workflow manually once to seed both OS caches immediately

## Validation
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/lake-cache.yml`
- Ruby YAML parse for the same workflow files
- `git diff --check`