### PR TITLE
ci: add aggregate alls-green status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,3 +425,18 @@ jobs:
             exit 1
           fi
           test ! -e "$tmp/home"
+
+  alls-green:
+    name: All checks green
+    if: always()
+    needs:
+      - rust
+      - real-e2e
+      - negative-audit
+      - installer
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Decide whether all required jobs succeeded
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary
- Add an always-running `alls-green` CI job named `All checks green`
- Gate it on the existing voting CI jobs: Rust, real e2e, negative audit, and installer
- Use `re-actors/alls-green@release/v1` with `jobs: ${{ toJSON(needs) }}` so one branch protection status can represent the full PR CI result

## Branch protection
After this lands, add the `All checks green` status check to the GitHub branch protection/ruleset required checks. You should not need to list each matrix/job individually for PR merge protection.

## Validation
- `/private/tmp/actionlint-bin/actionlint .github/workflows/ci.yml`
- Ruby YAML parse for `.github/workflows/ci.yml`
- `git diff --check`