### PR TITLE
ci: cache built Lake package artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  TAMA_LAKE_CACHE_SCHEMA: tama-lake-v3
+  TAMA_LAKE_CACHE_SCHEMA: tama-lake-v4
   TAMA_LAKE_PACKAGE_CACHE: ${{ github.workspace }}/.cache/tama/lake-packages
 
 jobs:

--- a/.github/workflows/lake-cache.yml
+++ b/.github/workflows/lake-cache.yml
@@ -21,7 +21,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  TAMA_LAKE_CACHE_SCHEMA: tama-lake-v3
+  TAMA_LAKE_CACHE_SCHEMA: tama-lake-v4
   TAMA_LAKE_PACKAGE_CACHE: ${{ github.workspace }}/.cache/tama/lake-packages
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  TAMA_LAKE_CACHE_SCHEMA: tama-lake-v3
+  TAMA_LAKE_CACHE_SCHEMA: tama-lake-v4
   TAMA_LAKE_PACKAGE_CACHE: ${{ github.workspace }}/.cache/tama/lake-packages
 
 jobs:

--- a/crates/tama-cli/src/main.rs
+++ b/crates/tama-cli/src/main.rs
@@ -1938,7 +1938,17 @@ fn should_replace_cached_package(source: &Utf8Path, target: &Utf8Path) -> Result
     }
     let source_rev = git_head_rev(source).ok();
     let target_rev = git_head_rev(target).ok();
-    Ok(source_rev.is_none() || source_rev != target_rev)
+    if source_rev.is_none() || source_rev != target_rev {
+        return Ok(true);
+    }
+    Ok(lake_build_artifacts_present(source) && !lake_build_artifacts_present(target))
+}
+
+fn lake_build_artifacts_present(package: &Utf8Path) -> bool {
+    let build = package.join(".lake/build");
+    std::fs::read_dir(build)
+        .map(|mut entries| entries.next().is_some())
+        .unwrap_or(false)
 }
 
 fn should_seed_manifest_package(target: &Utf8Path, expected_rev: &str) -> Result<bool, String> {
@@ -3313,6 +3323,49 @@ mod tests {
 
         tama_common::write_string(&cache.join("verity/untracked.lean"), "local change\n").unwrap();
         assert!(should_replace_cached_package(&package, &cache.join("verity")).unwrap());
+    }
+
+    #[test]
+    fn lake_package_cache_refreshes_matching_revisions_missing_build_artifacts() {
+        let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(dir.path().join("project")).unwrap();
+        let cache = Utf8PathBuf::from_path_buf(dir.path().join("cache")).unwrap();
+        let package = root.join(".lake/packages/verity");
+
+        init_git_package(&package, "same").unwrap();
+        tama_common::write_string(&package.join(".gitignore"), ".lake/\n").unwrap();
+        run_process("git", &["add", ".gitignore"], Some(&package)).unwrap();
+        run_process(
+            "git",
+            &[
+                "-c",
+                "user.name=Tama Test",
+                "-c",
+                "user.email=tama@example.test",
+                "commit",
+                "-m",
+                "ignore lake builds",
+            ],
+            Some(&package),
+        )
+        .unwrap();
+
+        sync_lake_package_cache(&root, &cache).unwrap();
+        assert!(!should_replace_cached_package(&package, &cache.join("verity")).unwrap());
+
+        let build_artifact = package.join(".lake/build/lib/Compiler.olean");
+        tama_common::write_string(&build_artifact, "compiled\n").unwrap();
+
+        assert!(git_worktree_clean(&package).unwrap());
+        assert!(should_replace_cached_package(&package, &cache.join("verity")).unwrap());
+
+        sync_lake_package_cache(&root, &cache).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(cache.join("verity/.lake/build/lib/Compiler.olean")).unwrap(),
+            "compiled\n"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix Lake package cache refresh so same-revision packages are replaced when the source has `.lake/build` artifacts and the cached copy does not
- Add a unit test for the exact failure mode where a pre-build package checkout blocks post-build artifacts from being cached
- Bump the shared Lake cache schema to `tama-lake-v4` so main warms a fresh cache instead of reusing the incomplete v3 cache

## Verification
- Confirmed current v3 caches exist and restore, but were saved without Verity/EVMYul build artifacts, which is why CI still rebuilt `Compiler.*`, `EvmYul.*`, and `Verity.*`
- `cargo fmt --check`
- `cargo test -p tama-cli lake_package_cache_refreshes_matching_revisions_missing_build_artifacts`
- `cargo test -p tama-cli lake_package_cache`
- `/private/tmp/actionlint-bin/actionlint .github/workflows/ci.yml .github/workflows/lake-cache.yml .github/workflows/release.yml`
- Ruby YAML parse for CI, Lake Cache, and release workflows
- `git diff --check`