### PR TITLE
ci: gate release version against tag

### DIFF
--- a/.github/scripts/check-release-version.sh
+++ b/.github/scripts/check-release-version.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag="${1:-${TAMA_RELEASE_TAG:-${GITHUB_REF_NAME:-}}}"
+if [ -z "$tag" ]; then
+  echo "release tag is required; pass it as argv[1] or set TAMA_RELEASE_TAG/GITHUB_REF_NAME" >&2
+  exit 1
+fi
+
+case "$tag" in
+  v*) ;;
+  *)
+    echo "release tag must start with v: $tag" >&2
+    exit 1
+    ;;
+esac
+
+expected="${tag#v}"
+if [ -z "$expected" ]; then
+  echo "release tag is missing a version: $tag" >&2
+  exit 1
+fi
+
+metadata="$(mktemp)"
+trap 'rm -f "$metadata"' EXIT
+
+cargo metadata --locked --format-version=1 --no-deps > "$metadata"
+python3 - "$expected" "$metadata" <<'PY'
+import json
+import sys
+
+expected = sys.argv[1]
+metadata_path = sys.argv[2]
+with open(metadata_path, encoding="utf-8") as file:
+    metadata = json.load(file)
+
+workspace_members = set(metadata["workspace_members"])
+versions = {
+    package["name"]: package["version"]
+    for package in metadata["packages"]
+    if package["id"] in workspace_members
+}
+bad = {
+    name: version
+    for name, version in sorted(versions.items())
+    if version != expected
+}
+if bad:
+    lines = [f"{name}={version}" for name, version in bad.items()]
+    raise SystemExit(
+        "release tag does not match workspace package versions: "
+        + ", ".join(lines)
+        + f"; expected {expected}"
+    )
+
+required = {"tama-cli", "tamaup-cli"}
+missing = sorted(required - set(versions))
+if missing:
+    raise SystemExit(
+        "release version check is missing expected packages: " + ", ".join(missing)
+    )
+PY
+
+cargo build -p tama-cli -p tamaup-cli --bins
+
+tama_version="$(target/debug/tama --version)"
+if [ "$tama_version" != "tama $expected" ]; then
+  echo "tama --version mismatch: got '$tama_version', expected 'tama $expected'" >&2
+  exit 1
+fi
+
+tamaup_version="$(target/debug/tamaup --version)"
+if [ "$tamaup_version" != "tamaup $expected" ]; then
+  echo "tamaup --version mismatch: got '$tamaup_version', expected 'tamaup $expected'" >&2
+  exit 1
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,21 @@ env:
   TAMA_LAKE_PACKAGE_CACHE: ${{ github.workspace }}/.cache/tama/lake-packages
 
 jobs:
+  release-version:
+    name: Release version matches tag
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check Cargo and CLI versions
+        shell: bash
+        run: bash .github/scripts/check-release-version.sh
+
   verify:
     name: Verify release ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    needs: release-version
     strategy:
       fail-fast: false
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "tama-audit"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "camino",
  "regex",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "tama-build"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "camino",
  "regex",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "tama-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "tama-common"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "camino",
  "hex",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "tama-config"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "camino",
  "serde",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "tama-inspect"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "camino",
  "serde",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "tama-manifest"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "camino",
  "regex",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "tama-project"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "camino",
  "serde",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "tama-toolchain"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "camino",
  "hex",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "tamaup-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.1.0"
+version = "0.1.1"
 rust-version = "1.81"
 license = "MIT"
 authors = ["zefram.eth"]


### PR DESCRIPTION
## Summary
- bump workspace package version to 0.1.1
- add a release preflight script that requires tag, workspace package versions, and built CLI --version outputs to agree
- make the release verify matrix depend on that preflight

## Verification
- bash .github/scripts/check-release-version.sh v0.1.1
- negative probe with v0.1.2 fails as expected
- cargo test -p tama-cli -p tamaup-cli
- cargo fmt --check
- git diff --check