### PR TITLE
Fix starter CI on fresh checkouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,10 +113,21 @@ jobs:
           tmp="$(mktemp -d)"
           project="$tmp/my-protocol"
           tama init "$project"
-          cd "$project"
+          git -C "$project" add .
+          git -C "$project" \
+            -c user.name=tama-ci \
+            -c user.email=tama-ci@example.invalid \
+            commit -m "starter checkout fixture"
+          checkout="$tmp/my-protocol-checkout"
+          git clone --recurse-submodules "$project" "$checkout"
+          cd "$checkout"
+          test ! -d artifacts/yul
+          test ! -d artifacts/lean
           test -f .github/workflows/ci.yml
           test -f .gitignore
           actionlint -color .github/workflows/ci.yml
+          tama doctor --fix
+          git diff --exit-code -- tama.lock lakefile.toml lake-manifest.json
           tama doctor
           tama check
           tama build --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,18 @@ jobs:
           tmp="$(mktemp -d)"
           project="$tmp/my-protocol"
           tama init "$project"
-          cd "$project"
+          git -C "$project" add .
+          git -C "$project" \
+            -c user.name=tama-ci \
+            -c user.email=tama-ci@example.invalid \
+            commit -m "starter checkout fixture"
+          checkout="$tmp/my-protocol-checkout"
+          git clone --recurse-submodules "$project" "$checkout"
+          cd "$checkout"
+          test ! -d artifacts/yul
+          test ! -d artifacts/lean
+          tama doctor --fix
+          git diff --exit-code -- tama.lock lakefile.toml lake-manifest.json
           tama doctor
           tama check
           tama build --locked

--- a/crates/tama-project/src/lib.rs
+++ b/crates/tama-project/src/lib.rs
@@ -1192,10 +1192,12 @@ Set `ERC20LITE_OWNER=<address>` to choose an owner other than Foundry's sender.
 
 ## Continuous integration
 
-`.github/workflows/ci.yml` runs `tama doctor`, `tama check`, `tama build
---locked`, `tama test`, and `tama audit` on every push and pull request. The
-first run installs Lean (elan), Foundry, solc 0.8.33, and Tama; later runs
-reuse caches keyed on `lake-manifest.json` and `tama.lock`.
+`.github/workflows/ci.yml` runs `tama doctor --fix` for checkout-only generated
+directories, verifies tracked dependency files did not change, then runs
+`tama doctor`, `tama check`, `tama build --locked`, `tama test`, and
+`tama audit` on every push and pull request. The first run installs Lean (elan),
+Foundry, solc 0.8.33, and Tama; later runs reuse caches keyed on
+`lake-manifest.json` and `tama.lock`.
 "#;
 
 #[cfg(test)]
@@ -1390,6 +1392,9 @@ metadata_bytecode_hash = "none"
         let workflow = read_to_string(&workflow_path).unwrap();
         for needle in [
             "name: CI",
+            "submodules: recursive",
+            "tama doctor --fix",
+            "git diff --exit-code -- tama.lock lakefile.toml lake-manifest.json",
             "tama doctor",
             "tama check",
             "tama build --locked",

--- a/crates/tama-project/src/templates/starter-ci.yml
+++ b/crates/tama-project/src/templates/starter-ci.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Cache Lake packages and Tama artifacts
         uses: actions/cache@v4
@@ -106,6 +108,8 @@ jobs:
           forge --version
           solc --version
 
+      - run: tama doctor --fix
+      - run: git diff --exit-code -- tama.lock lakefile.toml lake-manifest.json
       - run: tama doctor
       - run: tama check
       - run: tama build --locked


### PR DESCRIPTION
## Summary
- Make generated starter CI checkout submodules and run tama doctor --fix before validation.
- Guard the repair with git diff on tracked dependency files so stale lock or dependency drift still fails CI.
- Update Tama CI and release quickstarts to commit and clone the generated starter before running the starter commands.

## Tests
- cargo fmt --check
- cargo test -p tama-project init_creates_github_actions_workflow
- cargo test -p tama-project starter_ci_workflow_is_valid_yaml
- cargo test -p tama-cli doctor_reports_and_repairs_missing_generated_dirs
- python3 YAML parse for CI, release, and starter workflow files
- git diff --check
- local clone simulation for ignored artifacts directories plus doctor --fix
