### PR TITLE
Fix release workflow module paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,9 +142,9 @@ jobs:
           fi
           tama new TipJar
           tama check
-          printf '%s\n' '#check this_is_not_in_scope_for_tama_check' >> verity/proof/TipJarProof.lean
+          printf '%s\n' '#check this_is_not_in_scope_for_tama_check' >> verity/proof/MyProtocol/Proof/TipJarProof.lean
           tama check
-          printf '%s\n' '#check this_breaks_tama_check' >> verity/spec/TipJarSpec.lean
+          printf '%s\n' '#check this_breaks_tama_check' >> verity/spec/MyProtocol/Spec/TipJarSpec.lean
           if tama check; then
             echo "expected tama check to fail after breaking a spec module" >&2
             exit 1
@@ -273,7 +273,7 @@ jobs:
           }
 
           project="$(copy_case deleted-source)"
-          rm "$project/verity/src/ERC20Lite.lean"
+          rm "$project/verity/src/Base/ERC20Lite.lean"
           expect_audit_failure "$project" structure
 
           project="$(copy_case corrupted-selector)"
@@ -322,6 +322,8 @@ jobs:
           import sys
           path = sys.argv[1]
           data = json.load(open(path, encoding="utf-8"))
+          if len(data["storage"]) < 2:
+              raise SystemExit("fixture needs at least two storage entries")
           data["storage"][1]["slot"] = data["storage"][0]["slot"]
           json.dump(data, open(path, "w", encoding="utf-8"), indent=2)
           PY


### PR DESCRIPTION
Summary:
- update release e2e checks for package-root scaffold paths
- update release negative audit deleted-source fixture path
- mirror the storage fixture guard already used in CI

Tests:
- cargo fmt --check
- git diff --check

Context:
- fixes v0.1.4 release workflow failures caused by stale release-only hardcoded paths