### PR TITLE
Enforce Lean spec dischargers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - run: cargo fmt --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace
@@ -58,6 +60,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Restore Lake package cache
         id: tama-lake-cache
         uses: actions/cache/restore@v4
@@ -177,6 +181,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Restore Lake package cache
         id: tama-lake-cache
         uses: actions/cache/restore@v4
@@ -413,6 +419,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Install installer test tools
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - run: shellcheck installer/install.sh

--- a/.github/workflows/lake-cache.yml
+++ b/.github/workflows/lake-cache.yml
@@ -75,6 +75,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         if: steps.tama-lake-cache.outputs.cache-hit != 'true'
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
         if: steps.tama-lake-cache.outputs.cache-hit != 'true'
       - uses: ./.github/actions/install-toolchain
         if: steps.tama-lake-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Check Cargo and CLI versions
         shell: bash
         run: bash .github/scripts/check-release-version.sh
@@ -49,6 +51,8 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - run: cargo fmt --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace
@@ -69,6 +73,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Restore Lake package cache
         id: tama-lake-cache
         uses: actions/cache/restore@v4
@@ -203,6 +209,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Restore Lake package cache
         id: tama-lake-cache
         uses: actions/cache/restore@v4
@@ -438,6 +446,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Install installer test tools
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - run: shellcheck installer/install.sh
@@ -485,6 +495,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - run: cargo build --workspace --release
       - name: Pack archive
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "tama-audit"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "camino",
  "regex",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "tama-build"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "camino",
  "regex",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "tama-cli"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anstream",
  "anstyle",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "tama-common"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "camino",
  "hex",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "tama-config"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "camino",
  "serde",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "tama-inspect"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "camino",
  "serde",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "tama-manifest"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "camino",
  "regex",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "tama-project"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "camino",
  "serde",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "tama-toolchain"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "camino",
  "hex",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "tamaup-cli"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.1.4"
+version = "0.1.5"
 rust-version = "1.81"
 license = "MIT"
 authors = ["zefram.eth"]

--- a/crates/tama-build/src/lib.rs
+++ b/crates/tama-build/src/lib.rs
@@ -204,7 +204,7 @@ impl Pipeline {
             };
         progress.run(
             "trust-probe",
-            "Lean records proof dependencies for audit",
+            "Lean validates dischargers and records proof dependencies",
             "trust-boundary inputs written",
             || generate_trust_probe(&self.root, &config, &manifests),
         )?;
@@ -1358,15 +1358,20 @@ fn run_capture(program: &str, args: &[&str], cwd: &Utf8Path) -> Result<CommandOu
     if output.status.success() {
         Ok(CommandOutput { stdout })
     } else {
+        let details = [stderr.trim(), stdout.trim()]
+            .into_iter()
+            .filter(|text| !text.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n");
         Err(Error::Process {
             program: program.to_string(),
             message: format!(
                 "exited with status {}{}",
                 output.status,
-                if stderr.trim().is_empty() {
+                if details.is_empty() {
                     String::new()
                 } else {
-                    format!(": {}", stderr.trim())
+                    format!(": {details}")
                 }
             ),
         })
@@ -2321,7 +2326,16 @@ fn generate_trust_probe(
     let source_path = probe_dir.join("CollectAxioms.lean");
     let source = collect_axioms_probe_source(manifests, &obligations)?;
     tama_common::write_string(&source_path, &source)?;
-    let output = run_capture("lake", &["env", "lean", source_path.as_str()], root)?;
+    let output = match run_capture("lake", &["env", "lean", source_path.as_str()], root) {
+        Ok(output) => output,
+        Err(Error::Process { program, message }) => {
+            if let Some(message) = parse_discharge_probe_error(&message) {
+                return Err(Error::Adapter(message));
+            }
+            return Err(Error::Process { program, message });
+        }
+        Err(err) => return Err(err),
+    };
     let report = parse_collect_axioms_output(&output.stdout, &obligations)?;
     let report_text = serde_json::to_string_pretty(&report)
         .map_err(|err| Error::Adapter(format!("failed to serialize trust report: {err}")))?;
@@ -2330,6 +2344,7 @@ fn generate_trust_probe(
 }
 
 const COLLECT_AXIOMS_MARKER: &str = "TAMA_AXIOMS_JSON ";
+const DISCHARGE_ERROR_MARKER: &str = "TAMA_DISCHARGE_ERROR ";
 
 fn collect_axioms_probe_source(
     manifests: &[ContractManifest],
@@ -2350,6 +2365,63 @@ fn collect_axioms_probe_source(
     out.push_str(
         r#"
 open Lean
+open Lean.Meta
+
+def tamaSpecType (specDecl : String) (specName : Name) (dischargerDecl : String) : CoreM Expr := do
+  let env ← getEnv
+  match env.find? specName with
+  | some info => pure info.type
+  | none => throwError m!"TAMA_DISCHARGE_ERROR spec={specDecl} discharger={dischargerDecl}: missing spec declaration"
+
+def tamaDischargerType (specDecl : String) (dischargerDecl : String) (dischargerName : Name) : CoreM Expr := do
+  let env ← getEnv
+  match env.find? dischargerName with
+  | some info => pure info.type
+  | none => throwError m!"TAMA_DISCHARGE_ERROR spec={specDecl} discharger={dischargerDecl}: missing discharger declaration"
+
+partial def tamaZetaHead (e : Expr) : MetaM Expr := do
+  let e := e.consumeMData
+  match e with
+  | .letE _ _ value body _ => tamaZetaHead (body.instantiate1 value)
+  | _ => pure e
+
+partial def tamaFinalTheoremTarget (e : Expr) : MetaM Expr := do
+  let e ← tamaZetaHead e
+  match e with
+  | .forallE name domain body info =>
+      if (← isProp domain) then
+        pure e
+      else
+        withLocalDecl name info domain fun x =>
+          tamaFinalTheoremTarget (body.instantiate1 x)
+  | _ => pure e
+
+partial def tamaTargetContainsSpec (specName : Name) (target : Expr) : MetaM Bool := do
+  let target ← tamaZetaHead target
+  if target.isAppOf specName then
+    return true
+  let (head, args) := target.getAppFnArgs
+  if head == ``And && args.size == 2 then
+    return (← tamaTargetContainsSpec specName args[0]!) || (← tamaTargetContainsSpec specName args[1]!)
+  return false
+
+def tamaSpecIsPropValued (specDecl : String) (specName : Name) (dischargerDecl : String) : CoreM Unit := do
+  let specType ← tamaSpecType specDecl specName dischargerDecl
+  let ok ← MetaM.run'
+    (forallTelescopeReducing specType (cleanupAnnotations := true) (whnfType := true) fun _ target =>
+      pure target.consumeMData.isProp)
+  unless ok do
+    throwError m!"TAMA_DISCHARGE_ERROR spec={specDecl} discharger={dischargerDecl}: spec declaration is not Prop-valued"
+
+def tamaCheckDischarges (specDecl : String) (specName : Name) (dischargerDecl : String) (dischargerName : Name) : CoreM Unit := do
+  tamaSpecIsPropValued specDecl specName dischargerDecl
+  let theoremType ← tamaDischargerType specDecl dischargerDecl dischargerName
+  let ok ← MetaM.run'
+    (do
+      let target ← tamaFinalTheoremTarget theoremType
+      tamaTargetContainsSpec specName target)
+  unless ok do
+    throwError m!"TAMA_DISCHARGE_ERROR spec={specDecl} discharger={dischargerDecl}: theorem target is not the spec application or a positive conjunction containing it"
 
 def tamaAxiomJson (decl : String) (constName : Name) : CoreM Json := do
   let env ← getEnv
@@ -2367,6 +2439,16 @@ def tamaEmitAxioms (decl : String) (constName : Name) : CoreM Unit := do
   IO.println ("TAMA_AXIOMS_JSON " ++ entry.compress)
 "#,
     );
+    for obligation in obligations {
+        let spec_name = lean_name_literal(&obligation.lean_decl)?;
+        for discharger in &obligation.dischargers {
+            let discharger_name = lean_name_literal(discharger)?;
+            out.push_str(&format!(
+                "\n#eval show CoreM Unit from tamaCheckDischarges \"{}\" {} \"{}\" {}\n",
+                obligation.lean_decl, spec_name, discharger, discharger_name
+            ));
+        }
+    }
     let dischargers = obligations
         .iter()
         .flat_map(|obligation| obligation.dischargers.iter().map(String::as_str))
@@ -2378,6 +2460,15 @@ def tamaEmitAxioms (decl : String) (constName : Name) : CoreM Unit := do
         ));
     }
     Ok(out)
+}
+
+fn parse_discharge_probe_error(message: &str) -> Option<String> {
+    let (_, tail) = message.split_once(DISCHARGE_ERROR_MARKER)?;
+    let reason = tail.lines().next()?.trim();
+    if reason.is_empty() {
+        return None;
+    }
+    Some(format!("trust probe discharge validation failed: {reason}"))
 }
 
 fn parse_collect_axioms_output(output: &str, obligations: &[&Obligation]) -> Result<Value> {
@@ -4091,9 +4182,16 @@ TAMA_AXIOMS_END proof.CounterProof.increment_meets_spec
         let source = collect_axioms_probe_source(&[manifest], &[&obligation]).unwrap();
 
         assert!(source.contains("collectAxioms constName"));
+        assert!(source.contains("tamaCheckDischarges"));
         assert!(source.contains("tamaEmitAxioms"));
         assert!(!source.contains("Json.arr obligations"));
         assert!(!source.contains("let obligations :="));
+        assert_eq!(
+            source
+                .matches("#eval show CoreM Unit from tamaCheckDischarges")
+                .count(),
+            2
+        );
         assert_eq!(
             source
                 .matches("#eval show CoreM Unit from tamaEmitAxioms")
@@ -4116,7 +4214,40 @@ TAMA_AXIOMS_END proof.CounterProof.increment_meets_spec
 
         assert!(source.contains("import Tamago.Proof.CounterProof"));
         assert!(source.contains(
+            "#eval show CoreM Unit from tamaCheckDischarges \"Tamago.Spec.CounterSpec.increment_spec\" `Tamago.Spec.CounterSpec.increment_spec \"Tamago.Proof.CounterProof.increment_meets_spec\" `Tamago.Proof.CounterProof.increment_meets_spec"
+        ));
+        assert!(source.contains(
             "#eval show CoreM Unit from tamaEmitAxioms \"Tamago.Proof.CounterProof.increment_meets_spec\" `Tamago.Proof.CounterProof.increment_meets_spec"
+        ));
+    }
+
+    #[test]
+    fn collect_axioms_probe_checks_every_spec_discharger_pair() {
+        let obligation = fixture_obligation();
+        let mut second = fixture_decrement_obligation();
+        second.lean_decl = "spec.CounterSpec.bounds_spec".to_string();
+        second.dischargers = obligation.dischargers.clone();
+        let manifest = test_manifest("Counter");
+
+        let source = collect_axioms_probe_source(&[manifest], &[&obligation, &second]).unwrap();
+
+        assert_eq!(
+            source
+                .matches("#eval show CoreM Unit from tamaCheckDischarges")
+                .count(),
+            2
+        );
+        assert_eq!(
+            source
+                .matches("#eval show CoreM Unit from tamaEmitAxioms")
+                .count(),
+            1
+        );
+        assert!(source.contains(
+            "#eval show CoreM Unit from tamaCheckDischarges \"spec.CounterSpec.increment_spec\" `spec.CounterSpec.increment_spec \"proof.CounterProof.increment_meets_spec\" `proof.CounterProof.increment_meets_spec"
+        ));
+        assert!(source.contains(
+            "#eval show CoreM Unit from tamaCheckDischarges \"spec.CounterSpec.bounds_spec\" `spec.CounterSpec.bounds_spec \"proof.CounterProof.increment_meets_spec\" `proof.CounterProof.increment_meets_spec"
         ));
     }
 
@@ -4194,6 +4325,12 @@ lake noise after probe output
                 .count(),
             400
         );
+        assert_eq!(
+            source
+                .matches("#eval show CoreM Unit from tamaCheckDischarges")
+                .count(),
+            400
+        );
 
         let output = obligations
             .iter()
@@ -4255,6 +4392,17 @@ TAMA_AXIOMS_JSON {"lean_decl":"proof.CounterProof.increment_meets_spec","axioms"
         assert!(
             matches!(err, Error::Adapter(message) if message.contains("malformed axiom marker JSON"))
         );
+    }
+
+    #[test]
+    fn discharge_probe_errors_are_adapted() {
+        let message = "exited with status 1: CollectAxioms.lean:91:0: error: TAMA_DISCHARGE_ERROR spec=spec.CounterSpec.increment_spec discharger=proof.CounterProof.increment_meets_spec: theorem target is not the spec application or a positive conjunction containing it";
+
+        let adapted = parse_discharge_probe_error(message).unwrap();
+
+        assert!(adapted.contains("spec=spec.CounterSpec.increment_spec"));
+        assert!(adapted.contains("discharger=proof.CounterProof.increment_meets_spec"));
+        assert!(adapted.contains("theorem target is not the spec application"));
     }
 
     #[test]

--- a/crates/tama-cli/src/main.rs
+++ b/crates/tama-cli/src/main.rs
@@ -51,7 +51,7 @@ What gets built:
   proof-check      Lake builds the configured proof aggregate so Lean elaborates implementation, spec, and proof modules
   verity-codegen   Verity emits Yul, ABI, storage, assumption, and trust reports
   manifest         Tama adapts and validates generated contract manifests
-  trust-probe      Lean records proof dependencies used by `tama audit trust-boundary`
+  trust-probe      Lean validates dischargers and records proof dependencies
   solc             solc compiles generated Yul through standard JSON and records bytecode hashes
   bridge           Tama generates Solidity interfaces and deployers from the validated manifest
   forge            Foundry compiles generated Solidity and project tests

--- a/docs/reference/SPEC.md
+++ b/docs/reference/SPEC.md
@@ -105,7 +105,7 @@ def transfer_preserves_totalSupply := ...
 end MyProtocol.Spec.FooSpec
 ```
 
-`FooProof.lean` imports `FooSpec.lean` and contains the theorems that discharge those obligations. Each discharging theorem carries a `-- tama: discharges=<spec_name>` comment directly above it (multiple comma-separated spec names are allowed, with no whitespace after commas). Multiple theorems may discharge one spec; one theorem may discharge several. Theorems and `lemma`s without a `discharges=` tag are silently treated as helpers and never appear in the manifest.
+`FooProof.lean` imports `FooSpec.lean` and contains the theorems that discharge those obligations. Each discharging theorem carries a `-- tama: discharges=<spec_name>` comment directly above it (multiple comma-separated spec names are allowed, with no whitespace after commas). Multiple theorems may discharge one spec; one theorem may discharge several. The tag is checked by Lean: after elaboration, the theorem target must be the named spec application directly, or a positive conjunction containing that spec application. Theorems and `lemma`s without a `discharges=` tag are silently treated as helpers and never appear in the manifest.
 
 Foundry tests that mirror specs live under the configured mirror test path (typically `test/verity/`). Each mirror is a `testFuzz*` or `invariant_*` function carrying a `// tama: mirrors=<spec_name>` Solidity comment directly above the function declaration. Putting a `mirrors=` tag on a plain `test_*` function is a build error.
 
@@ -674,6 +674,8 @@ function invariant_totalSupplyTracksMinted() public view {
 
 Tag rules: `discharges=<spec_name>[,<spec_name>...]` (no whitespace after commas) on Lean theorems, and `mirrors=<spec_name>[,<spec_name>...]` on Solidity functions. Each spec name on the right of `discharges=` must be a real top-level def in the same contract's spec file; each spec name on the right of `mirrors=` must be a real spec in some contract. Unknown names are build-time errors.
 
+`discharges=` is not metadata-only. During `tama build`, the generated Lean trust probe checks the theorem's elaborated proposition. Accepted theorem targets are a direct spec application, or a positive `And` conjunction containing that spec application. Rejected shapes include unrelated theorems, `True`, arbitrary assumptions such as `P -> spec ...`, disjunctions, existentials, and helper-position mentions of the spec. Put preconditions inside the spec definition itself; after the theorem target is the spec application, the proof may unfold the spec and introduce those preconditions normally.
+
 Proof-only exemptions live in `tama.toml`:
 
 ```toml
@@ -709,8 +711,9 @@ For each spec, Tama queries or extracts the Lean environment dependency set of e
 
 The axiom allowlist lives in `tama.toml` under `[trust.allow_axioms]`. `sorryAx` is hard-denied and is not allowlistable for `tama audit`. Compiler-reported trust surfaces live under `[trust.allow_surfaces]` and use the exact identifier reported in `artifacts/trust-report.json`.
 
-The generated trust probe uses Lean's `collectAxioms` API and writes
-`artifacts/trust-probe/axioms.json` with schema `tama.trust-probe.v1`.
+The generated trust probe validates each `discharges=` claim, then uses
+Lean's `collectAxioms` API and writes `artifacts/trust-probe/axioms.json`
+with schema `tama.trust-probe.v1`.
 
 Tama also consumes Verity compiler trust-surface artifacts when present. `artifacts/trust-report.json` localizes unsupported or partially modeled mechanics, unsafe blocks, and unchecked dependency buckets; `artifacts/assumption-report.json` flattens undischarged compiler assumptions. Trust surfaces must be explicitly allowlisted by their stable surface identifier. Undischarged assumptions must be explicitly allowlisted by their stable assumption or axiom identifier.
 
@@ -908,8 +911,8 @@ Commands:
 ```text
 tamaup                       # install/update latest stable
 tamaup install nightly       # install nightly channel
-tamaup install 0.1.3         # install specific version
-tamaup use 0.1.3             # switch active version
+tamaup install 0.1.5         # install specific version
+tamaup use 0.1.5             # switch active version
 tamaup list                  # installed versions
 tamaup self update           # update tamaup itself
 tamaup uninstall             # remove tama; keep tamaup

--- a/site/src/pages/concepts.mdx
+++ b/site/src/pages/concepts.mdx
@@ -119,11 +119,13 @@ file; they are internal scaffolding and never appear in the manifest.
 A theorem in the proof file
 [`verity/proof/<Contract>Proof.lean`](verity/proof) marked with a
 `-- tama: discharges=<spec>` comment on the line above. The tag claims
-the spec definition named on the right. Multiple comma-separated names
-are allowed (no whitespace after commas), one theorem can discharge
-several specs, and several theorems can discharge one spec. Theorems
-and `lemma`s without a `discharges=` tag are silently treated as
-helpers and never appear in the manifest.
+the spec definition named on the right, and Tama asks Lean to verify the
+elaborated theorem target is that spec application directly or a
+positive conjunction containing it. Multiple comma-separated names are
+allowed (no whitespace after commas), one theorem can discharge several
+specs, and several theorems can discharge one spec. Theorems and
+`lemma`s without a `discharges=` tag are silently treated as helpers and
+never appear in the manifest.
 
 ### Mirror test
 

--- a/site/src/pages/guides/audits.mdx
+++ b/site/src/pages/guides/audits.mdx
@@ -116,7 +116,9 @@ What it inspects:
   Foundry mirror or a [`[coverage.proof_only]`](/reference/config)
   entry in `tama.toml`.
 - Every `-- tama: discharges=<spec>` tag in the proof file names a
-  real top-level def in the same contract's spec file.
+  real top-level def in the same contract's spec file, and `tama build`
+  has checked that the tagged theorem target is the spec application or
+  a positive conjunction containing it.
 - Every `// tama: mirrors=<spec>` tag sits directly above a function
   named `testFuzz*` or `invariant_*`, and names a real spec in some
   contract.

--- a/site/src/pages/guides/proofs.mdx
+++ b/site/src/pages/guides/proofs.mdx
@@ -50,13 +50,13 @@ each theorem that discharges an obligation carries a
 ```lean
 namespace FooProof
 
--- tama: discharges=total_in_range
+-- tama: discharges=total_in_range_after_mint
 theorem mint_preserves_total_in_range
-    (pre : Foo.State) (call : Foo.Call)
-    (h : FooSpec.total_in_range pre)
-    (k : pre.total + call.amount ≤ pre.cap) :
-    FooSpec.total_in_range (Foo.mint pre call) := by
-  simp [FooSpec.total_in_range, Foo.mint]
+    (pre : Foo.State) (call : Foo.Call) :
+    FooSpec.total_in_range_after_mint pre call := by
+  unfold FooSpec.total_in_range_after_mint
+  intro h k
+  simp [Foo.mint, h, k]
   omega
 
 end FooProof
@@ -74,6 +74,13 @@ Multiple theorems may discharge the same spec (cover one branch each,
 for instance), and one theorem may discharge several specs. Every name
 on the right of `discharges=` must be a real top-level def in the
 contract's spec file; an unknown name is a build error.
+
+Tama checks the elaborated theorem target in Lean. A tagged theorem must
+target the named spec application directly, or a positive conjunction
+containing it. `True`, unrelated specs, `P -> spec ...`, disjunctions,
+existentials, and helper-position mentions do not discharge the spec.
+Put preconditions inside the spec definition, then unfold the spec in
+the proof and introduce those assumptions there.
 
 Theorems and `lemma`s without a `discharges=` tag are silently treated
 as helpers — Tama never reads them and the manifest never mentions
@@ -182,5 +189,6 @@ anything you allowlist is a project-level choice, not a framework one.
   Verity side — start here before reaching for `sorry`.
 - Read [the audit guide](/guides/audits) — many "proof failures" are
   actually structural mistakes (e.g. a `discharges=` tag pointing at a
-  spec name that doesn't exist) that the audit reports more clearly
-  than the build does.
+  spec name that doesn't exist, or a theorem target that does not
+  actually contain the spec application) that the build reports before
+  audit inputs are written.

--- a/site/src/pages/guides/starter.mdx
+++ b/site/src/pages/guides/starter.mdx
@@ -277,7 +277,8 @@ by hand.)
 The model is symmetric. The spec file declares an obligation by
 defining `transfer_total_supply_preserved`; the proof claims it with
 `-- tama: discharges=transfer_total_supply_preserved` directly above
-the theorem; the Foundry test mirrors it with a matching
+the theorem, and Lean checks that the theorem target is that spec
+application; the Foundry test mirrors it with a matching
 `// tama: mirrors=transfer_total_supply_preserved` (next section).
 Theorems and `lemma`s without a `discharges=` tag are silently treated
 as helpers; the ten other obligations each carry their own

--- a/site/src/pages/install.astro
+++ b/site/src/pages/install.astro
@@ -37,8 +37,8 @@ import Callout from "../components/Callout.astro";
     remove specific Tama releases:
   </p>
 
-  <pre><code>tamaup install 0.1.4      # install a specific release
-tamaup use 0.1.4          # switch the active version
+  <pre><code>tamaup install 0.1.5      # install a specific release
+tamaup use 0.1.5          # switch the active version
 tamaup install nightly    # install the nightly channel
 tamaup list               # show installed versions
 tamaup self update        # update tamaup itself

--- a/site/src/pages/reference/cli.mdx
+++ b/site/src/pages/reference/cli.mdx
@@ -140,7 +140,7 @@ Steps:
 1. `lake build MyProtocol.Proof` — Lean elaborates implementation, spec, and proof. The target is the configured proof aggregate module; legacy projects without `[modules]` use `TamaProof`.
 2. `lake exe verity-compiler` — emits Yul, ABI, storage, trust reports.
 3. Tama adapts compiler output into `tama.contract-manifest.v1` files.
-4. Lean records proof dependencies into `artifacts/trust-probe/axioms.json`.
+4. Lean validates `discharges=` claims and records proof dependencies into `artifacts/trust-probe/axioms.json`.
 5. Tama validates each manifest's schema and artifact paths.
 6. `solc --standard-json` compiles each Yul into bytecode per `[yul]`.
 7. Tama generates Solidity interfaces and deployers from the manifests.
@@ -389,8 +389,8 @@ Version manager for `tama`.
 ```text
 tamaup                    install/update latest stable
 tamaup install nightly    install nightly channel
-tamaup install 0.1.4      install specific version
-tamaup use 0.1.4          switch active version
+tamaup install 0.1.5      install specific version
+tamaup use 0.1.5          switch active version
 tamaup list               installed versions
 tamaup self update        update tamaup itself
 tamaup uninstall          remove tama (keep tamaup)

--- a/site/src/pages/start.mdx
+++ b/site/src/pages/start.mdx
@@ -171,26 +171,23 @@ open TipjarProtocol.TipJar
 
 -- tama: discharges=total_tracks_balances
 theorem deposit_preserves_invariant
-    (pre : TipJar.State) (call : TipJar.Call)
-    (h : TipJarSpec.total_tracks_balances pre) :
+    (pre : TipJar.State) (call : TipJar.Call) :
     TipJarSpec.total_tracks_balances (TipJar.deposit pre call) := by
   simp [TipJarSpec.total_tracks_balances, TipJar.deposit,
-        Mapping.sumValues_update_add]
+         Mapping.sumValues_update_add]
 
 -- tama: discharges=total_tracks_balances
 theorem withdraw_preserves_invariant
-    (pre : TipJar.State) (amount : UInt256)
-    (h : TipJarSpec.total_tracks_balances pre)
-    (k : pre.balances[msg.sender] ≥ amount) :
+    (pre : TipJar.State) (amount : UInt256) :
     TipJarSpec.total_tracks_balances (TipJar.withdraw pre amount) := by
   simp [TipJarSpec.total_tracks_balances, TipJar.withdraw,
-        Mapping.sumValues_update_sub k]
+         Mapping.sumValues_update_sub]
 
 end TipjarProtocol.Proof.TipJarProof
 ```
 
-Each theorem says: *if the invariant holds before the call, it holds
-after the call.* The `by simp [...]` is the proof — Lean's simplifier
+Each theorem targets the spec application named by `discharges=`. The
+`by simp [...]` is the proof — Lean's simplifier
 unfolds the definitions and the lemmas listed, and Verity's standard
 library takes care of the mapping arithmetic.
 [Verity's debugging-proofs guide](https://veritylang.com/guides/debugging-proofs)
@@ -201,6 +198,9 @@ from `TipjarProtocol/Spec/TipJarSpec.lean`. Two theorems can discharge the same 
 (as above), one theorem can discharge several (`discharges=foo,bar`),
 and any theorem or `lemma` without a `discharges=` tag is silently
 treated as a helper and never appears in the manifest.
+If a proof needs preconditions, put them inside the spec definition;
+after the theorem target is the spec application, unfold the spec and
+introduce those assumptions in the proof.
 
 ## Step 5 — Write the mirror test
 
@@ -265,7 +265,7 @@ Build steps:
   ok   verity-codegen  compiler artifacts generated
   run  manifest        Tama adapts Verity outputs into contract manifests
   ok   manifest        2 manifests: ERC20Lite, TipJar
-  run  trust-probe     Lean records proof dependencies for audit
+  run  trust-probe     Lean validates dischargers and records proof dependencies
   ok   trust-probe     trust-boundary inputs written
   run  solc            TipJar Yul through solc 0.8.33 standard JSON
   ok   solc            TipJar bytecode and hash written


### PR DESCRIPTION
## Summary
- validate each manifest spec/discharger pair in the generated Lean trust probe
- accept direct spec targets and positive conjunctions while rejecting unrelated theorem shapes
- keep the trust-probe JSON shape unchanged and update docs/CLI wording
- bump Tama to 0.1.5

## Verification
- cargo test -p tama-build
- cargo test -p tama-build -p tama-audit -p tama-inspect
- cargo test --workspace
- cargo test -p tama-build -p tama-cli
- target/debug/tama build --root fixtures/projects/counter
- negative smoke: changed a tagged Counter proof to True and confirmed trust-probe fails