### PR TITLE
Discover dischargers from the Lean environment, not proof-file tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "tama-audit"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "camino",
  "regex",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "tama-build"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "camino",
  "regex",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "tama-cli"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "tama-common"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "camino",
  "hex",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "tama-config"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "camino",
  "serde",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "tama-inspect"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "camino",
  "serde",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "tama-manifest"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "camino",
  "regex",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "tama-project"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "camino",
  "serde",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "tama-toolchain"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "camino",
  "hex",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "tamaup-cli"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.1.5"
+version = "0.1.6"
 rust-version = "1.81"
 license = "MIT"
 authors = ["zefram.eth"]

--- a/crates/tama-build/src/lib.rs
+++ b/crates/tama-build/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::Write;
 use std::process::{Command, Stdio};
@@ -202,6 +202,12 @@ impl Pipeline {
                     return Err(err);
                 }
             };
+        progress.run(
+            "dischargers",
+            "Lean discovers proof dischargers by spec type",
+            "dischargers resolved",
+            || discover_dischargers(&self.root, &config, &mut manifests),
+        )?;
         progress.run(
             "trust-probe",
             "Lean validates dischargers and records proof dependencies",
@@ -598,16 +604,10 @@ pub fn adapt_verity_outputs(
             .get(&contract)
             .cloned()
             .unwrap_or_default();
-        let dischargers = extract_dischargers(
-            &root.join(&source.paths.proof),
-            &source.modules.proof_module,
-            &specs,
-        )?;
         let obligations = merge_obligations(
             &contract,
             &source.modules.spec_module,
             &specs,
-            &dischargers,
             &mirrors_index,
             &config.coverage.proof_only,
         );
@@ -649,8 +649,9 @@ pub fn adapt_verity_outputs(
                     .join(format!("{contract}Deployer.sol")),
             },
         };
-        let out = manifest_dir.join(format!("{contract}.json"));
-        manifest.write_pretty(&out)?;
+        // The manifest is incomplete here (dischargers are still empty). It is
+        // first persisted — validated — by the `discover_dischargers` step, so
+        // a failed build never leaves an invalid manifest on disk.
         manifests.push(manifest);
     }
     if manifests.is_empty() {
@@ -1931,63 +1932,6 @@ fn top_level_keyword(line: &str, keyword: &str) -> bool {
     }
 }
 
-fn extract_dischargers(
-    proof_path: &Utf8Path,
-    proof_module: &str,
-    known_specs: &[String],
-) -> Result<HashMap<String, Vec<String>>> {
-    let mut map: HashMap<String, Vec<String>> = HashMap::new();
-    if !proof_path.is_file() {
-        return Ok(map);
-    }
-    let text = tama_common::read_to_string(proof_path)?;
-    let theorem_re = Regex::new(
-        r"^\s*(?:@\[[^\]]*\]\s*)*(?:(?:private|protected)\s+)*(?:theorem|lemma)\s+([A-Za-z_][A-Za-z0-9_.']*)",
-    )
-    .expect("valid theorem regex");
-    let stripped = strip_lean_block_comments(&text);
-    let known: BTreeSet<&str> = known_specs.iter().map(String::as_str).collect();
-    let mut pending: Vec<String> = Vec::new();
-    for line in stripped.lines() {
-        let trimmed = line.trim();
-        if let Some(raw) = trimmed.strip_prefix("-- tama:") {
-            let values = parse_key_values(raw);
-            for key in values.keys() {
-                if key.as_str() != "discharges" {
-                    return Err(Error::Adapter(format!(
-                        "{proof_path}: unsupported Tama metadata key `{key}` (proof tags accept only `discharges=`)"
-                    )));
-                }
-            }
-            if let Some(value) = values.get("discharges") {
-                for spec in value.split(',').map(str::trim).filter(|s| !s.is_empty()) {
-                    if !known.contains(spec) {
-                        return Err(Error::Adapter(format!(
-                            "{proof_path}: discharges=`{spec}` does not match any spec in this contract"
-                        )));
-                    }
-                    pending.push(spec.to_string());
-                }
-            }
-            continue;
-        }
-        if let Some(captures) = theorem_re.captures(trimmed) {
-            if !pending.is_empty() {
-                let name = captures.get(1).unwrap().as_str();
-                let decl = format!("{proof_module}.{name}");
-                for spec in pending.drain(..) {
-                    map.entry(spec).or_default().push(decl.clone());
-                }
-            }
-            continue;
-        }
-        if !trimmed.is_empty() && !trimmed.starts_with("--") && !trimmed.starts_with("@[") {
-            pending.clear();
-        }
-    }
-    Ok(map)
-}
-
 fn extract_mirrors(
     root: &Utf8Path,
     test_dir: &Utf8Path,
@@ -2186,14 +2130,12 @@ fn merge_obligations(
     contract: &str,
     spec_module: &str,
     specs: &[String],
-    dischargers: &HashMap<String, Vec<String>>,
     mirrors: &BTreeMap<(String, String), Vec<String>>,
     proof_only: &BTreeMap<String, String>,
 ) -> Vec<Obligation> {
     let mut out = Vec::with_capacity(specs.len());
     for name in specs {
         let id = format!("{contract}.{name}");
-        let dischargers_for_spec = dischargers.get(name).cloned().unwrap_or_default();
         let mirrors_for_spec = mirrors
             .get(&(contract.to_string(), name.clone()))
             .cloned()
@@ -2204,7 +2146,7 @@ fn merge_obligations(
             name: name.clone(),
             lean_decl: format!("{spec_module}.{name}"),
             contract: contract.to_string(),
-            dischargers: dischargers_for_spec,
+            dischargers: Vec::new(),
             mirrors: mirrors_for_spec,
             proof_only_reason,
         });
@@ -2345,6 +2287,39 @@ fn generate_trust_probe(
 
 const COLLECT_AXIOMS_MARKER: &str = "TAMA_AXIOMS_JSON ";
 const DISCHARGE_ERROR_MARKER: &str = "TAMA_DISCHARGE_ERROR ";
+const DISCHARGER_MARKER: &str = "TAMA_DISCHARGER_JSON ";
+
+/// Lean meta-helpers that define the discharge criterion: strip non-`Prop`
+/// binders to the theorem's final target, then accept only the spec applied or
+/// a positive conjunction containing it. Shared verbatim by discharger
+/// discovery and the trust probe so both judge dischargers identically.
+const TAMA_TARGET_HELPERS: &str = r#"
+partial def tamaZetaHead (e : Expr) : MetaM Expr := do
+  let e := e.consumeMData
+  match e with
+  | .letE _ _ value body _ => tamaZetaHead (body.instantiate1 value)
+  | _ => pure e
+
+partial def tamaFinalTheoremTarget (e : Expr) : MetaM Expr := do
+  let e ← tamaZetaHead e
+  match e with
+  | .forallE name domain body info =>
+      if (← isProp domain) then
+        pure e
+      else
+        withLocalDecl name info domain fun x =>
+          tamaFinalTheoremTarget (body.instantiate1 x)
+  | _ => pure e
+
+partial def tamaTargetContainsSpec (specName : Name) (target : Expr) : MetaM Bool := do
+  let target ← tamaZetaHead target
+  if target.isAppOf specName then
+    return true
+  let (head, args) := target.getAppFnArgs
+  if head == ``And && args.size == 2 then
+    return (← tamaTargetContainsSpec specName args[0]!) || (← tamaTargetContainsSpec specName args[1]!)
+  return false
+"#;
 
 fn collect_axioms_probe_source(
     manifests: &[ContractManifest],
@@ -2378,33 +2353,11 @@ def tamaDischargerType (specDecl : String) (dischargerDecl : String) (discharger
   match env.find? dischargerName with
   | some info => pure info.type
   | none => throwError m!"TAMA_DISCHARGE_ERROR spec={specDecl} discharger={dischargerDecl}: missing discharger declaration"
-
-partial def tamaZetaHead (e : Expr) : MetaM Expr := do
-  let e := e.consumeMData
-  match e with
-  | .letE _ _ value body _ => tamaZetaHead (body.instantiate1 value)
-  | _ => pure e
-
-partial def tamaFinalTheoremTarget (e : Expr) : MetaM Expr := do
-  let e ← tamaZetaHead e
-  match e with
-  | .forallE name domain body info =>
-      if (← isProp domain) then
-        pure e
-      else
-        withLocalDecl name info domain fun x =>
-          tamaFinalTheoremTarget (body.instantiate1 x)
-  | _ => pure e
-
-partial def tamaTargetContainsSpec (specName : Name) (target : Expr) : MetaM Bool := do
-  let target ← tamaZetaHead target
-  if target.isAppOf specName then
-    return true
-  let (head, args) := target.getAppFnArgs
-  if head == ``And && args.size == 2 then
-    return (← tamaTargetContainsSpec specName args[0]!) || (← tamaTargetContainsSpec specName args[1]!)
-  return false
-
+"#,
+    );
+    out.push_str(TAMA_TARGET_HELPERS);
+    out.push_str(
+        r#"
 def tamaSpecIsPropValued (specDecl : String) (specName : Name) (dischargerDecl : String) : CoreM Unit := do
   let specType ← tamaSpecType specDecl specName dischargerDecl
   let ok ← MetaM.run'
@@ -2460,6 +2413,144 @@ def tamaEmitAxioms (decl : String) (constName : Name) : CoreM Unit := do
         ));
     }
     Ok(out)
+}
+
+/// Resolves each obligation's dischargers from the elaborated Lean environment:
+/// the theorems in the contract's proof namespace whose final target is the
+/// spec application (or a positive conjunction containing it). File-layout
+/// independent, so proofs split across submodules are handled.
+fn discover_dischargers(
+    root: &Utf8Path,
+    config: &TamaConfig,
+    manifests: &mut [ContractManifest],
+) -> Result<()> {
+    if manifests
+        .iter()
+        .all(|manifest| manifest.obligations.is_empty())
+    {
+        return Ok(());
+    }
+    let probe_dir = root.join(config.paths.out.join("dischargers"));
+    fs::create_dir_all(&probe_dir)
+        .map_err(|source| tama_common::io_error(probe_dir.clone(), source))?;
+    let source_path = probe_dir.join("Discover.lean");
+    let source = discover_dischargers_source(manifests)?;
+    tama_common::write_string(&source_path, &source)?;
+    let output = run_capture("lake", &["env", "lean", source_path.as_str()], root)?;
+    parse_discharger_output(&output.stdout, manifests)?;
+    let manifest_dir = root.join(config.paths.out.join("manifest"));
+    for manifest in manifests.iter() {
+        manifest.write_pretty(&manifest_dir.join(format!("{}.json", manifest.contract)))?;
+    }
+    Ok(())
+}
+
+fn discover_dischargers_source(manifests: &[ContractManifest]) -> Result<String> {
+    let mut modules = manifests
+        .iter()
+        .map(|manifest| manifest.lean.proof_module.as_str())
+        .collect::<Vec<_>>();
+    modules.sort_unstable();
+    modules.dedup();
+    let mut out = String::from(
+        "-- Generated by Tama. Discharger discovery via the Lean environment.\nimport Lean\n",
+    );
+    for module in modules {
+        validate_lean_name(module)?;
+        out.push_str(&format!("import {module}\n"));
+    }
+    out.push_str("\nopen Lean\nopen Lean.Meta\n");
+    out.push_str(TAMA_TARGET_HELPERS);
+    out.push_str(
+        r#"
+-- One fold over the environment dispatches each theorem to the proof namespace
+-- (group) that owns it, so the scan is not repeated per contract.
+def tamaEmitDischargers (groups : List (Name × List (String × Name))) : MetaM Unit := do
+  let env ← getEnv
+  for (declName, info) in env.constants.toList do
+    match info with
+    | .thmInfo ti =>
+        if !declName.isInternal then
+          -- A declaration can sit under more than one group when proof
+          -- namespaces nest (`proof.Foo` is a prefix of `proof.Foo.Bar`), so
+          -- check every prefix-matching group, not just the first.
+          let matching := groups.filter (fun group => group.1.isPrefixOf declName)
+          unless matching.isEmpty do
+            let target ← tamaFinalTheoremTarget ti.type
+            for (_, specs) in matching do
+              for (specDecl, specName) in specs do
+                if (← tamaTargetContainsSpec specName target) then
+                  IO.println ("TAMA_DISCHARGER_JSON " ++ (Json.mkObj [("spec", Json.str specDecl), ("discharger", Json.str (declName.toString))]).compress)
+    | _ => pure ()
+"#,
+    );
+    let mut groups = Vec::new();
+    for manifest in manifests {
+        if manifest.obligations.is_empty() {
+            continue;
+        }
+        let ns_lit = lean_name_literal(&manifest.lean.proof_module)?;
+        let mut specs = Vec::with_capacity(manifest.obligations.len());
+        for obligation in &manifest.obligations {
+            let name_lit = lean_name_literal(&obligation.lean_decl)?;
+            specs.push(format!("(\"{}\", {})", obligation.lean_decl, name_lit));
+        }
+        groups.push(format!("({ns_lit}, [{}])", specs.join(", ")));
+    }
+    if !groups.is_empty() {
+        out.push_str(&format!(
+            "\n#eval tamaEmitDischargers [{}]\n",
+            groups.join(", ")
+        ));
+    }
+    Ok(out)
+}
+
+fn parse_discharger_output(output: &str, manifests: &mut [ContractManifest]) -> Result<()> {
+    let mut map: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for line in output.lines() {
+        let Some(rest) = line.trim().strip_prefix(DISCHARGER_MARKER) else {
+            continue;
+        };
+        let value: Value = serde_json::from_str(rest).map_err(|err| {
+            Error::Adapter(format!(
+                "discharger discovery emitted malformed marker JSON: {err}"
+            ))
+        })?;
+        let spec = value.get("spec").and_then(Value::as_str).ok_or_else(|| {
+            Error::Adapter("discharger discovery marker missing `spec`".to_string())
+        })?;
+        let discharger = value
+            .get("discharger")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                Error::Adapter("discharger discovery marker missing `discharger`".to_string())
+            })?;
+        // The manifest and trust probe reference dischargers as plain dotted
+        // identifiers, so skip any Lean `Name` that does not round-trip (e.g.
+        // guillemet-escaped or Unicode components). Such a name could otherwise
+        // poison a spec that already has a usable discharger; if it leaves a
+        // spec with none, the zero-discharger check below reports it clearly.
+        if !tama_manifest::is_qualified_lean_name(discharger) {
+            continue;
+        }
+        map.entry(spec.to_string())
+            .or_default()
+            .insert(discharger.to_string());
+    }
+    for manifest in manifests.iter_mut() {
+        for obligation in &mut manifest.obligations {
+            let found = map.get(&obligation.lean_decl).cloned().unwrap_or_default();
+            if found.is_empty() {
+                return Err(Error::Adapter(format!(
+                    "no proof theorem in `{}` discharges `{}`: a discharger must be a theorem whose conclusion is the spec applied (or a positive conjunction containing it), with no extra hypotheses",
+                    manifest.lean.proof_module, obligation.lean_decl
+                )));
+            }
+            obligation.dischargers = found.into_iter().collect();
+        }
+    }
+    Ok(())
 }
 
 fn parse_discharge_probe_error(message: &str) -> Option<String> {
@@ -3263,30 +3354,6 @@ end spec.Foo
     }
 
     #[test]
-    fn extract_dischargers_preserves_lean_prime_suffix() {
-        let dir = tempfile::tempdir().unwrap();
-        let proof = Utf8PathBuf::from_path_buf(dir.path().to_path_buf())
-            .unwrap()
-            .join("Proof.lean");
-        tama_common::write_string(
-            &proof,
-            r#"namespace proof.Foo
-
--- tama: discharges=transfer'
-theorem transfer'_meets : True := by trivial
-
-end proof.Foo
-"#,
-        )
-        .unwrap();
-        let map = extract_dischargers(&proof, "proof.Foo", &["transfer'".to_string()]).unwrap();
-        assert_eq!(
-            map.get("transfer'").map(|v| v.as_slice()),
-            Some(&["proof.Foo.transfer'_meets".to_string()][..])
-        );
-    }
-
-    #[test]
     fn extract_specs_rejects_forbidden_top_level_form() {
         let dir = tempfile::tempdir().unwrap();
         let spec = Utf8PathBuf::from_path_buf(dir.path().to_path_buf())
@@ -3332,96 +3399,6 @@ end spec.Foo
         assert!(matches!(
             err,
             Error::Adapter(message) if message.contains("must not carry `-- tama:` comments")
-        ));
-    }
-
-    #[test]
-    fn extract_dischargers_parses_discharges_tag() {
-        let dir = tempfile::tempdir().unwrap();
-        let proof = Utf8PathBuf::from_path_buf(dir.path().to_path_buf())
-            .unwrap()
-            .join("Proof.lean");
-        tama_common::write_string(
-            &proof,
-            r#"namespace proof.CounterProof
-
--- tama: discharges=increment_spec
-theorem increment_meets_spec : True := by trivial
-
--- tama: discharges=getCount_spec,getCount_preserves_state_spec
-theorem getCount_combo : True := by trivial
-
-lemma helper : True := by trivial
-
-end proof.CounterProof
-"#,
-        )
-        .unwrap();
-        let specs = vec![
-            "increment_spec".to_string(),
-            "getCount_spec".to_string(),
-            "getCount_preserves_state_spec".to_string(),
-        ];
-        let map = extract_dischargers(&proof, "proof.CounterProof", &specs).unwrap();
-        assert_eq!(
-            map.get("increment_spec").unwrap(),
-            &vec!["proof.CounterProof.increment_meets_spec".to_string()]
-        );
-        assert_eq!(
-            map.get("getCount_spec").unwrap(),
-            &vec!["proof.CounterProof.getCount_combo".to_string()]
-        );
-        assert_eq!(
-            map.get("getCount_preserves_state_spec").unwrap(),
-            &vec!["proof.CounterProof.getCount_combo".to_string()]
-        );
-    }
-
-    #[test]
-    fn extract_dischargers_rejects_unknown_spec() {
-        let dir = tempfile::tempdir().unwrap();
-        let proof = Utf8PathBuf::from_path_buf(dir.path().to_path_buf())
-            .unwrap()
-            .join("Proof.lean");
-        tama_common::write_string(
-            &proof,
-            r#"namespace proof.Foo
-
--- tama: discharges=does_not_exist
-theorem t : True := by trivial
-
-end proof.Foo
-"#,
-        )
-        .unwrap();
-        let err = extract_dischargers(&proof, "proof.Foo", &["foo_spec".to_string()]).unwrap_err();
-        assert!(matches!(
-            err,
-            Error::Adapter(message) if message.contains("does not match any spec")
-        ));
-    }
-
-    #[test]
-    fn extract_dischargers_rejects_unknown_key() {
-        let dir = tempfile::tempdir().unwrap();
-        let proof = Utf8PathBuf::from_path_buf(dir.path().to_path_buf())
-            .unwrap()
-            .join("Proof.lean");
-        tama_common::write_string(
-            &proof,
-            r#"namespace proof.Foo
-
--- tama: discharges=foo_spec coverage=mirror
-theorem t : True := by trivial
-
-end proof.Foo
-"#,
-        )
-        .unwrap();
-        let err = extract_dischargers(&proof, "proof.Foo", &["foo_spec".to_string()]).unwrap_err();
-        assert!(matches!(
-            err,
-            Error::Adapter(message) if message.contains("unsupported Tama metadata key `coverage`")
         ));
     }
 
@@ -3687,12 +3664,6 @@ contract ConcreteFooTest is FooTestBase {
         let root =
             Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/projects/counter");
         let specs = extract_specs(&root.join("verity/spec/CounterSpec.lean")).unwrap();
-        let dischargers = extract_dischargers(
-            &root.join("verity/proof/CounterProof.lean"),
-            "proof.CounterProof",
-            &specs,
-        )
-        .unwrap();
         let mut spec_owner = BTreeMap::new();
         for name in &specs {
             spec_owner.insert(name.clone(), "Counter".to_string());
@@ -3704,11 +3675,9 @@ contract ConcreteFooTest is FooTestBase {
         assert!(test.contains("handlerDecrement"));
         assert!(test.contains("contract CounterTest is MinimalStdInvariant"));
         assert!(test.contains("function targetSelectors()"));
+        // Dischargers are resolved by a Lean meta-pass (`discover_dischargers`),
+        // not by scanning the proof file, so coverage here checks specs + mirrors.
         for spec in &specs {
-            assert!(
-                dischargers.contains_key(spec),
-                "spec `{spec}` has no discharger"
-            );
             let key = ("Counter".to_string(), spec.clone());
             assert!(mirrors.contains_key(&key), "spec `{spec}` has no mirror");
         }
@@ -3729,7 +3698,10 @@ contract ConcreteFooTest is FooTestBase {
             manifests[0].artifacts.yul,
             Utf8PathBuf::from("artifacts/yul/Counter.yul")
         );
-        assert!(root.join("artifacts/manifest/Counter.json").is_file());
+        // `adapt_verity_outputs` returns in-memory manifests and creates the
+        // output directory; the manifest file is first written (validated) by
+        // the `discover_dischargers` step.
+        assert!(root.join("artifacts/manifest").is_dir());
     }
 
     #[test]
@@ -3864,10 +3836,9 @@ contract ConcreteFooTest is FooTestBase {
             manifest.obligations[0].lean_decl,
             "spec.defi.VaultSpec.balance_spec"
         );
-        assert_eq!(
-            manifest.obligations[0].dischargers,
-            vec!["proof.defi.VaultProof.balance_meets_spec".to_string()]
-        );
+        // `adapt_verity_outputs` builds obligations with empty dischargers;
+        // they are populated later by the `discover_dischargers` Lean pass.
+        assert!(manifest.obligations[0].dischargers.is_empty());
         assert_eq!(
             manifest.obligations[0].mirrors,
             vec!["test/verity/defi/Vault.t.sol:VaultTest.testFuzzBalance".to_string()]
@@ -4218,6 +4189,113 @@ TAMA_AXIOMS_END proof.CounterProof.increment_meets_spec
         ));
         assert!(source.contains(
             "#eval show CoreM Unit from tamaEmitAxioms \"Tamago.Proof.CounterProof.increment_meets_spec\" `Tamago.Proof.CounterProof.increment_meets_spec"
+        ));
+    }
+
+    #[test]
+    fn discover_dischargers_source_emits_namespace_probe() {
+        let mut manifest = test_manifest("Counter");
+        manifest.obligations.push(fixture_obligation());
+        manifest.obligations.push(fixture_decrement_obligation());
+
+        let source = discover_dischargers_source(&[manifest]).unwrap();
+
+        assert!(source.contains("import proof.CounterProof"));
+        // The discharge criterion is shared verbatim with the trust probe.
+        assert!(source.contains("partial def tamaFinalTheoremTarget"));
+        assert!(source.contains("partial def tamaTargetContainsSpec"));
+        assert!(source.contains("def tamaEmitDischargers"));
+        // One fold over the environment dispatches by namespace group.
+        assert!(source.contains(
+            "#eval tamaEmitDischargers [(`proof.CounterProof, [(\"spec.CounterSpec.increment_spec\", `spec.CounterSpec.increment_spec), (\"spec.CounterSpec.decrement_spec\", `spec.CounterSpec.decrement_spec)])]"
+        ));
+    }
+
+    #[test]
+    fn discover_dischargers_source_dispatches_nested_namespaces() {
+        // Two contracts whose proof namespaces nest. Both must be passed as
+        // groups, and the fold must check each declaration against every
+        // matching group (`filter`, not first-match) so a theorem under the
+        // deeper namespace is still checked against the deeper contract's specs.
+        let mut outer = test_manifest("Foo");
+        outer.lean.proof_module = "proof.Foo".to_string();
+        let mut outer_ob = fixture_obligation();
+        outer_ob.lean_decl = "spec.Foo.outer_spec".to_string();
+        outer_ob.dischargers.clear();
+        outer.obligations.push(outer_ob);
+
+        let mut inner = test_manifest("Bar");
+        inner.lean.proof_module = "proof.Foo.Bar".to_string();
+        let mut inner_ob = fixture_obligation();
+        inner_ob.lean_decl = "spec.Foo.Bar.inner_spec".to_string();
+        inner_ob.dischargers.clear();
+        inner.obligations.push(inner_ob);
+
+        let source = discover_dischargers_source(&[outer, inner]).unwrap();
+
+        assert!(source.contains("groups.filter"));
+        assert!(!source.contains("groups.find?"));
+        assert!(source.contains("(`proof.Foo, [(\"spec.Foo.outer_spec\", `spec.Foo.outer_spec)])"));
+        assert!(source.contains(
+            "(`proof.Foo.Bar, [(\"spec.Foo.Bar.inner_spec\", `spec.Foo.Bar.inner_spec)])"
+        ));
+    }
+
+    #[test]
+    fn discover_dischargers_source_skips_contracts_without_obligations() {
+        let source = discover_dischargers_source(&[test_manifest("Counter")]).unwrap();
+        assert!(source.contains("import proof.CounterProof"));
+        assert!(!source.contains("#eval tamaEmitDischargers"));
+    }
+
+    #[test]
+    fn parse_discharger_output_fills_sorted_unique_dischargers() {
+        let mut manifest = test_manifest("Counter");
+        let mut increment = fixture_obligation();
+        increment.dischargers.clear();
+        let mut decrement = fixture_decrement_obligation();
+        decrement.dischargers.clear();
+        manifest.obligations.push(increment);
+        manifest.obligations.push(decrement);
+        let mut manifests = vec![manifest];
+
+        let output = concat!(
+            "TAMA_DISCHARGER_JSON {\"spec\":\"spec.CounterSpec.increment_spec\",\"discharger\":\"proof.CounterProof.increment_meets_spec\"}\n",
+            "unrelated probe noise\n",
+            "TAMA_DISCHARGER_JSON {\"spec\":\"spec.CounterSpec.decrement_spec\",\"discharger\":\"proof.CounterProof.decrement_b\"}\n",
+            "TAMA_DISCHARGER_JSON {\"spec\":\"spec.CounterSpec.decrement_spec\",\"discharger\":\"proof.CounterProof.decrement_a\"}\n",
+            "TAMA_DISCHARGER_JSON {\"spec\":\"spec.CounterSpec.decrement_spec\",\"discharger\":\"proof.CounterProof.decrement_b\"}\n",
+        );
+
+        parse_discharger_output(output, &mut manifests).unwrap();
+
+        assert_eq!(
+            manifests[0].obligations[0].dischargers,
+            vec!["proof.CounterProof.increment_meets_spec".to_string()]
+        );
+        assert_eq!(
+            manifests[0].obligations[1].dischargers,
+            vec![
+                "proof.CounterProof.decrement_a".to_string(),
+                "proof.CounterProof.decrement_b".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_discharger_output_errors_when_spec_has_no_discharger() {
+        let mut manifest = test_manifest("Counter");
+        let mut increment = fixture_obligation();
+        increment.dischargers.clear();
+        manifest.obligations.push(increment);
+        let mut manifests = vec![manifest];
+
+        let err = parse_discharger_output("", &mut manifests).unwrap_err();
+
+        assert!(matches!(
+            err,
+            Error::Adapter(message)
+                if message.contains("no proof theorem in `proof.CounterProof` discharges `spec.CounterSpec.increment_spec`")
         ));
     }
 

--- a/crates/tama-project/src/lib.rs
+++ b/crates/tama-project/src/lib.rs
@@ -666,13 +666,11 @@ open Verity.EVM.Uint256
 open {spec_module}
 open {src_module}.{name}
 
--- tama: discharges=setValue_spec
 theorem setValue_meets_spec (newValue : Uint256) (s : ContractState) :
   let s' := ((setValue newValue).run s).snd
   setValue_spec newValue s s' := by
   sorry
 
--- tama: discharges=getValue_spec
 theorem getValue_returns_value (s : ContractState) :
   let result := ((getValue).run s).fst
   getValue_spec result s := by
@@ -913,10 +911,11 @@ open Verity.EVM.Uint256
 open spec.ERC20LiteSpec
 open src.ERC20Lite
 
--- Each `tama: discharges=` comment binds a proof theorem to a spec; the spec
--- in turn is mirrored by a Foundry test (or listed under
--- `[coverage.proof_only]` in `tama.toml`).
--- tama: discharges=mint_owner_preserved
+-- Tama auto-discovers, from the proof namespace, each theorem whose conclusion
+-- is a spec application (or a positive conjunction containing one); no
+-- annotation is needed to bind a theorem to its spec. Each spec is in turn
+-- mirrored by a Foundry test (or listed under `[coverage.proof_only]` in
+-- `tama.toml`).
 theorem mint_preserves_owner_after_run (toAddr : Address) (amount : Uint256) (s : ContractState) :
   let s' := ((mint toAddr amount).run s).snd
   mint_owner_preserved s s' := by
@@ -936,7 +935,6 @@ theorem mint_preserves_owner_after_run (toAddr : Address) (amount : Uint256) (s 
   · simp [mint, ownerSlot, msgSender, getStorageAddr, Contract.run, ContractResult.snd,
       Verity.bind, Bind.bind, Verity.require, h_owner]
 
--- tama: discharges=transfer_total_supply_preserved
 theorem transfer_total_supply_preserved_after_run (toAddr : Address) (amount : Uint256) (s : ContractState) :
   let s' := ((transfer toAddr amount).run s).snd
   transfer_total_supply_preserved s s' := by
@@ -965,7 +963,6 @@ theorem transfer_total_supply_preserved_after_run (toAddr : Address) (amount : U
 -- `setMapping` literally produces — they are definitionally equal via the
 -- HSub instance, but simp on `+` fires `add_comm` while `sub` is left
 -- alone, so the two sides need to be brought into the same shape by hand.
--- tama: discharges=transfer_balances_effect
 theorem transfer_balances_effect_after_run
     (toAddr : Address) (amount : Uint256) (s : ContractState) :
   transfer_balances_effect toAddr amount s ((transfer toAddr amount).run s).snd := by
@@ -996,19 +993,16 @@ theorem transfer_balances_effect_after_run
         Verity.require, Verity.Stdlib.Math.requireSomeUint, Verity.Stdlib.Math.safeAdd,
         h_balance, h_ne, h_not_overflow_strict]
 
--- tama: discharges=balanceOf_spec
 theorem balanceOf_returns_storage_balance (account : Address) (s : ContractState) :
   let result := ((balanceOf account).run s).fst
   balanceOf_spec account result s := by
   simp [balanceOf_spec, balanceOf, balancesSlot, Bind.bind, Pure.pure]
 
--- tama: discharges=totalSupply_spec
 theorem totalSupply_returns_storage_supply (s : ContractState) :
   let result := ((totalSupply).run s).fst
   totalSupply_spec result s := by
   simp [totalSupply_spec, totalSupply, totalSupplySlot, Bind.bind, Pure.pure]
 
--- tama: discharges=owner_spec
 theorem owner_returns_storage_owner (s : ContractState) :
   let result := ((owner).run s).fst
   owner_spec result s := by
@@ -1018,7 +1012,6 @@ theorem owner_returns_storage_owner (s : ContractState) :
 -- and a revert carries the original state unchanged. Specs whose body is an
 -- implication are stated without `let s'` so `intro` reaches the antecedent
 -- directly (a `let` binder would otherwise be the first thing introduced).
--- tama: discharges=mint_unauthorized_no_change
 theorem mint_unauthorized_no_change_after_run
     (toAddr : Address) (amount : Uint256) (s : ContractState) :
   mint_unauthorized_no_change toAddr amount s ((mint toAddr amount).run s).snd := by
@@ -1031,7 +1024,6 @@ theorem mint_unauthorized_no_change_after_run
 -- Authorized-path effect: when sender = owner, `transferOwnership` writes the
 -- new owner into slot 0. The single-branch proof is the simplest shape — no
 -- case split, just unfold and let `setStorageAddr` rewrite the slot.
--- tama: discharges=transferOwnership_authorized_sets_owner
 theorem transferOwnership_authorized_sets_owner_after_run
     (newOwner : Address) (s : ContractState) :
   transferOwnership_authorized_sets_owner newOwner s
@@ -1043,7 +1035,6 @@ theorem transferOwnership_authorized_sets_owner_after_run
     Verity.require, h_owner]
 
 -- Negative access control: a non-owner caller leaves slot 0 untouched.
--- tama: discharges=transferOwnership_unauthorized_owner_unchanged
 theorem transferOwnership_unauthorized_owner_unchanged_after_run
     (newOwner : Address) (s : ContractState) :
   transferOwnership_unauthorized_owner_unchanged s
@@ -1057,7 +1048,6 @@ theorem transferOwnership_unauthorized_owner_unchanged_after_run
 -- Frame condition: `transferOwnership` never touches the totalSupply slot.
 -- The proof case-splits on authorization so the same statement covers both
 -- branches — the authorized branch does write a slot, just not slot 2.
--- tama: discharges=transferOwnership_supply_preserved
 theorem transferOwnership_supply_preserved_after_run
     (newOwner : Address) (s : ContractState) :
   let s' := ((transferOwnership newOwner).run s).snd
@@ -1072,7 +1062,6 @@ theorem transferOwnership_supply_preserved_after_run
       Verity.require, h_owner]
 
 -- Frame condition: `transferOwnership` never touches the balances mapping.
--- tama: discharges=transferOwnership_balances_preserved
 theorem transferOwnership_balances_preserved_after_run
     (account : Address) (newOwner : Address) (s : ContractState) :
   let s' := ((transferOwnership newOwner).run s).snd
@@ -1523,13 +1512,12 @@ srcDir = "{src_dir}"
         assert!(!proof.contains("Placeholder"));
         assert!(!proof.contains("kind="));
         assert!(!proof.contains("coverage="));
-        assert!(proof.contains("tama: discharges=transfer_total_supply_preserved"));
-        assert!(proof.contains("tama: discharges=transfer_balances_effect"));
-        assert!(proof.contains("tama: discharges=mint_unauthorized_no_change"));
-        assert!(proof.contains("tama: discharges=transferOwnership_authorized_sets_owner"));
-        assert!(proof.contains("tama: discharges=transferOwnership_unauthorized_owner_unchanged"));
-        assert!(proof.contains("tama: discharges=transferOwnership_supply_preserved"));
-        assert!(proof.contains("tama: discharges=transferOwnership_balances_preserved"));
+        // Dischargers are auto-discovered from the proof namespace, so the
+        // starter proof carries no discharge tags.
+        assert!(!proof.contains("tama: discharges="));
+        assert!(proof.contains("Tama auto-discovers"));
+        assert!(proof.contains("theorem transfer_total_supply_preserved_after_run"));
+        assert!(proof.contains("theorem transferOwnership_supply_preserved_after_run"));
         assert!(proof.contains("((transfer toAddr amount).run s).snd"));
         assert!(proof.contains("((mint toAddr amount).run s).snd"));
         assert!(proof.contains("((transferOwnership newOwner).run s).snd"));
@@ -1747,8 +1735,7 @@ srcDir = "{src_dir}"
         assert!(proof.contains("namespace MyProtocol.Proof.TipJarProof"));
         assert!(proof.contains("((setValue newValue).run s).snd"));
         assert!(proof.contains("((getValue).run s).fst"));
-        assert!(proof.contains("tama: discharges=setValue_spec"));
-        assert!(proof.contains("tama: discharges=getValue_spec"));
+        assert!(!proof.contains("tama: discharges="));
         assert!(proof.contains("sorry"));
         let test = read_to_string(&root.join("test/verity/TipJar.t.sol")).unwrap();
         assert!(test.contains(
@@ -1868,7 +1855,7 @@ srcDir = "{src_dir}"
         assert!(root.join("contracts/proof/TipJarProof.lean").is_file());
         assert!(root.join("tests/verity/TipJar.t.sol").is_file());
         let proof = read_to_string(&root.join("contracts/proof/TipJarProof.lean")).unwrap();
-        assert!(proof.contains("tama: discharges=setValue_spec"));
+        assert!(!proof.contains("tama: discharges="));
         let test = read_to_string(&root.join("tests/verity/TipJar.t.sol")).unwrap();
         assert!(test.contains("// tama: mirrors=setValue_spec"));
         assert!(!root.join("verity/src/TipJar.lean").exists());

--- a/docs/DISCHARGER_DISCOVERY_PLAN.md
+++ b/docs/DISCHARGER_DISCOVERY_PLAN.md
@@ -1,0 +1,87 @@
+# Discharger Discovery Plan
+
+## Purpose
+
+`tama build` resolves each obligation's dischargers by regex-scanning the single
+`{Contract}Proof.lean` file for `-- tama: discharges=` comments. When a proof is
+split across submodules, the tags live in the imported sub-files and the
+top-level file is tag-less, so Tama records zero dischargers for the contract and
+`manifest.validate()` fails with "requires at least one discharger". This plan
+replaces the single-file comment scan with namespace + type-based discovery via
+the elaborated Lean environment, so dischargers are found regardless of how the
+proof is split across files.
+
+## Steps
+
+1. In `crates/tama-build/src/lib.rs`, extract the trust probe's target-shape
+   helpers (`tamaZetaHead`, `tamaFinalTheoremTarget`, `tamaTargetContainsSpec`)
+   from `collect_axioms_probe_source` into a single `const TAMA_TARGET_HELPERS:
+   &str`, and reference that const from `collect_axioms_probe_source` so the
+   discovery pass and the trust probe share one definition of the discharge
+   criterion.
+2. Add `discover_dischargers(root, config, manifests: &mut [ContractManifest])`
+   in `crates/tama-build/src/lib.rs`. It writes a generated Lean file to
+   `artifacts/.../dischargers/Discover.lean`, runs `lake env lean <file>` from
+   `root` (same invocation shape as `generate_trust_probe`), parses the emitted
+   markers, and fills `obligation.dischargers` (sorted, de-duplicated) on each
+   manifest, then rewrites each manifest JSON.
+3. Implement `discover_dischargers_source(manifests)` returning the generated
+   Lean: `import Lean`, `import <each proof module>`, the shared
+   `TAMA_TARGET_HELPERS`, and one `#eval` per contract that folds over
+   `env.constants`, keeps `ConstantInfo.thmInfo` whose name has the proof
+   module's namespace as a `Name`-prefix and is not `isInternal`, computes
+   `tamaFinalTheoremTarget` once, and for each of that contract's spec decls
+   emits `TAMA_DISCHARGER_JSON {"spec":"<spec lean_decl>","discharger":"<thm>"}`
+   when `tamaTargetContainsSpec` holds.
+4. Implement `parse_discharger_output(stdout, manifests)` that reads the
+   `TAMA_DISCHARGER_JSON` markers into a `spec lean_decl -> BTreeSet<discharger>`
+   map. Error (`Error::Adapter`) if any obligation resolves to zero dischargers,
+   naming the spec `lean_decl` and the proof module, and stating that a
+   discharger must conclude the spec with no extra hypotheses.
+5. In `adapt_verity_outputs`, delete the `extract_dischargers` call and pass no
+   discharger map to `merge_obligations`; obligations are built with empty
+   `dischargers`. Remove `extract_dischargers` and drop the `dischargers`
+   parameter from `merge_obligations`.
+6. In `Pipeline::run` (`crates/tama-build/src/lib.rs`), add a `dischargers`
+   progress step between `manifest` and `trust-probe` that calls
+   `discover_dischargers(&self.root, &config, &mut manifests)`.
+7. Remove the now-dead tag machinery and tests: the `extract_dischargers_*`
+   unit tests and the direct `extract_dischargers` assertions; change
+   `adapter_accepts_nested_verity_files_and_mirror_tests` to assert
+   `dischargers` is empty (population is a separate Lean step). Add unit tests
+   for `discover_dischargers_source` (generated Lean string) and
+   `parse_discharger_output` (synthetic marker stdout, including the
+   zero-discharger error).
+8. In `fixtures/projects/counter/verity/proof/`, move two theorems into a new
+   `CounterProofParts.lean` declaring `namespace proof.CounterProof`, have
+   `CounterProof.lean` `import proof.CounterProofParts`, and remove every
+   `-- tama: discharges=` comment from both files, so the counter e2e exercises
+   split + tag-free discovery.
+9. In `crates/tama-project/src/lib.rs`, remove the `-- tama: discharges=`
+   comments and the comment teaching them from the starter proof templates;
+   leave the theorems unchanged.
+10. Update docs that teach the tag: `site/src/pages/{start,concepts}.mdx`,
+    `site/src/pages/guides/{proofs,starter,audits}.mdx`,
+    `site/src/pages/reference/{cli,manifest,artifacts}.mdx`, and
+    `docs/reference/SPEC.md`. State that dischargers are auto-discovered by type
+    from the proof namespace; keep the accepted/rejected target-shape criterion;
+    drop instructions to author `discharges=` tags.
+11. Bump the workspace `version` in `Cargo.toml` from `0.1.5` to `0.1.6`.
+
+## End state
+
+- A split-across-files proof builds: every obligation records at least one
+  discharger discovered from the proof namespace, with no `-- tama: discharges=`
+  tags present.
+- `extract_dischargers` and all `-- tama: discharges=` parsing are gone from
+  `crates/tama-build/src/lib.rs`; leftover tags in user proofs are inert.
+- `discover_dischargers` runs one `lake env lean` pass over the proof
+  namespaces, fills `obligation.dischargers` (sorted), and errors with a
+  spec-and-namespace message when a spec has no qualifying theorem.
+- The discharge criterion (theorem target is the spec application or a positive
+  conjunction containing it, after stripping non-Prop binders) is defined once
+  and shared by discovery and the trust probe.
+- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
+  and `cargo test --workspace` pass; the counter fixture passes `tama build`
+  end to end with a real Lean toolchain.
+- The workspace builds as `tama 0.1.6`.

--- a/docs/reference/SPEC.md
+++ b/docs/reference/SPEC.md
@@ -105,7 +105,7 @@ def transfer_preserves_totalSupply := ...
 end MyProtocol.Spec.FooSpec
 ```
 
-`FooProof.lean` imports `FooSpec.lean` and contains the theorems that discharge those obligations. Each discharging theorem carries a `-- tama: discharges=<spec_name>` comment directly above it (multiple comma-separated spec names are allowed, with no whitespace after commas). Multiple theorems may discharge one spec; one theorem may discharge several. The tag is checked by Lean: after elaboration, the theorem target must be the named spec application directly, or a positive conjunction containing that spec application. Theorems and `lemma`s without a `discharges=` tag are silently treated as helpers and never appear in the manifest.
+`FooProof.lean` imports `FooSpec.lean` and contains the theorems that discharge those obligations. Discharging theorems carry no Tama annotations: during `tama build`, a Lean meta-pass enumerates the theorems in the contract's proof namespace from the elaborated environment and records a theorem as a discharger of a spec when, after stripping its leading non-`Prop` binders (the data inputs), its conclusion is that spec application directly or a positive conjunction containing it. Discovery is file-layout independent — the proof may be split across imported submodules that share the proof namespace. Multiple theorems may discharge one spec; one theorem may discharge several (via a conjunction). Theorems whose conclusion is anything else are treated as helpers and never appear in the manifest.
 
 Foundry tests that mirror specs live under the configured mirror test path (typically `test/verity/`). Each mirror is a `testFuzz*` or `invariant_*` function carrying a `// tama: mirrors=<spec_name>` Solidity comment directly above the function declaration. Putting a `mirrors=` tag on a plain `test_*` function is a build error.
 
@@ -646,12 +646,12 @@ Mirror references must point to contract-qualified, property-shaped Foundry symb
 Example Lean shape (proof side):
 
 ```lean
--- tama: discharges=transfer_preserves_total_supply
-theorem transfer_preserves_total_supply_after_run : ... := by
+theorem transfer_preserves_total_supply_after_run :
+    ... transfer_preserves_total_supply ... := by
   ...
 
--- tama: discharges=mint_increases_total,mint_owner_preserved
-theorem mint_combined : ... := by
+theorem mint_combined :
+    ... mint_increases_total ... ∧ ... mint_owner_preserved ... := by
   ...
 
 theorem arithmetic_helper : ... := by
@@ -672,9 +672,9 @@ function invariant_totalSupplyTracksMinted() public view {
 }
 ```
 
-Tag rules: `discharges=<spec_name>[,<spec_name>...]` (no whitespace after commas) on Lean theorems, and `mirrors=<spec_name>[,<spec_name>...]` on Solidity functions. Each spec name on the right of `discharges=` must be a real top-level def in the same contract's spec file; each spec name on the right of `mirrors=` must be a real spec in some contract. Unknown names are build-time errors.
+Dischargers are not tagged: Tama discovers them by type from the contract's proof namespace (above and below). Mirrors are tagged with `mirrors=<spec_name>[,<spec_name>...]` (no whitespace after commas) on Solidity functions; each spec name on the right of `mirrors=` must be a real spec in some contract, and unknown names are build-time errors.
 
-`discharges=` is not metadata-only. During `tama build`, the generated Lean trust probe checks the theorem's elaborated proposition. Accepted theorem targets are a direct spec application, or a positive `And` conjunction containing that spec application. Rejected shapes include unrelated theorems, `True`, arbitrary assumptions such as `P -> spec ...`, disjunctions, existentials, and helper-position mentions of the spec. Put preconditions inside the spec definition itself; after the theorem target is the spec application, the proof may unfold the spec and introduce those preconditions normally.
+The discharge criterion is a check on the theorem's elaborated proposition. During `tama build`, the Lean meta-pass strips each theorem's leading non-`Prop` binders and inspects the resulting conclusion. Accepted theorem targets are a direct spec application, or a positive `And` conjunction containing that spec application. Rejected shapes include unrelated theorems, `True`, arbitrary assumptions such as `P -> spec ...`, disjunctions, existentials, and helper-position mentions of the spec. Put preconditions inside the spec definition itself; once the theorem target is the spec application, the proof may unfold the spec and introduce those preconditions normally.
 
 Proof-only exemptions live in `tama.toml`:
 
@@ -711,8 +711,8 @@ For each spec, Tama queries or extracts the Lean environment dependency set of e
 
 The axiom allowlist lives in `tama.toml` under `[trust.allow_axioms]`. `sorryAx` is hard-denied and is not allowlistable for `tama audit`. Compiler-reported trust surfaces live under `[trust.allow_surfaces]` and use the exact identifier reported in `artifacts/trust-report.json`.
 
-The generated trust probe validates each `discharges=` claim, then uses
-Lean's `collectAxioms` API and writes `artifacts/trust-probe/axioms.json`
+For every discharger discovered by the meta-pass, the generated trust probe
+uses Lean's `collectAxioms` API and writes `artifacts/trust-probe/axioms.json`
 with schema `tama.trust-probe.v1`.
 
 Tama also consumes Verity compiler trust-surface artifacts when present. `artifacts/trust-report.json` localizes unsupported or partially modeled mechanics, unsafe blocks, and unchecked dependency buckets; `artifacts/assumption-report.json` flattens undischarged compiler assumptions. Trust surfaces must be explicitly allowlisted by their stable surface identifier. Undischarged assumptions must be explicitly allowlisted by their stable assumption or axiom identifier.

--- a/fixtures/projects/counter/verity/proof/CounterProof.lean
+++ b/fixtures/projects/counter/verity/proof/CounterProof.lean
@@ -1,4 +1,5 @@
 import spec.CounterSpec
+import proof.CounterProofParts
 import Verity.Proofs.Stdlib.Automation
 
 namespace proof.CounterProof
@@ -8,7 +9,6 @@ open Verity.EVM.Uint256
 open spec.CounterSpec
 open src.Counter
 
--- tama: discharges=increment_spec
 theorem increment_meets_spec (s : ContractState) :
   let s' := ((increment).run s).snd
   increment_spec s s' := by
@@ -23,7 +23,6 @@ theorem increment_meets_spec (s : ContractState) :
       Specs.sameContext, increment, count, getStorage, setStorage, Contract.run,
       ContractResult.snd, Verity.bind, Bind.bind]
 
--- tama: discharges=decrement_spec
 theorem decrement_meets_spec (s : ContractState) :
   let s' := ((decrement).run s).snd
   decrement_spec s s' := by
@@ -37,19 +36,5 @@ theorem decrement_meets_spec (s : ContractState) :
   · simp [Specs.sameStorageAddr, Specs.sameStorageMap, Specs.sameStorageArray,
       Specs.sameContext, decrement, count, getStorage, setStorage, Contract.run,
       ContractResult.snd, Verity.bind, Bind.bind]
-
--- tama: discharges=getCount_spec
-theorem getCount_returns_count (s : ContractState) :
-  let result := ((getCount).run s).fst
-  getCount_spec result s := by
-  simp [getCount_spec, getCount, count, getStorage, Contract.run, ContractResult.fst,
-    Verity.bind, Bind.bind, Verity.pure, Pure.pure]
-
--- tama: discharges=getCount_preserves_state_spec
-theorem getCount_preserves_state (s : ContractState) :
-  let s' := ((getCount).run s).snd
-  getCount_preserves_state_spec s s' := by
-  simp [getCount_preserves_state_spec, getCount, count, getStorage, Contract.run,
-    ContractResult.snd, Verity.bind, Bind.bind, Verity.pure, Pure.pure]
 
 end proof.CounterProof

--- a/fixtures/projects/counter/verity/proof/CounterProofParts.lean
+++ b/fixtures/projects/counter/verity/proof/CounterProofParts.lean
@@ -1,0 +1,23 @@
+import spec.CounterSpec
+import Verity.Proofs.Stdlib.Automation
+
+namespace proof.CounterProof
+
+open Verity
+open Verity.EVM.Uint256
+open spec.CounterSpec
+open src.Counter
+
+theorem getCount_returns_count (s : ContractState) :
+  let result := ((getCount).run s).fst
+  getCount_spec result s := by
+  simp [getCount_spec, getCount, count, getStorage, Contract.run, ContractResult.fst,
+    Verity.bind, Bind.bind, Verity.pure, Pure.pure]
+
+theorem getCount_preserves_state (s : ContractState) :
+  let s' := ((getCount).run s).snd
+  getCount_preserves_state_spec s s' := by
+  simp [getCount_preserves_state_spec, getCount, count, getStorage, Contract.run,
+    ContractResult.snd, Verity.bind, Bind.bind, Verity.pure, Pure.pure]
+
+end proof.CounterProof

--- a/site/src/pages/concepts.mdx
+++ b/site/src/pages/concepts.mdx
@@ -116,16 +116,18 @@ file; they are internal scaffolding and never appear in the manifest.
 
 ### Discharger
 
-A theorem in the proof file
-[`verity/proof/<Contract>Proof.lean`](verity/proof) marked with a
-`-- tama: discharges=<spec>` comment on the line above. The tag claims
-the spec definition named on the right, and Tama asks Lean to verify the
-elaborated theorem target is that spec application directly or a
-positive conjunction containing it. Multiple comma-separated names are
-allowed (no whitespace after commas), one theorem can discharge several
-specs, and several theorems can discharge one spec. Theorems and
-`lemma`s without a `discharges=` tag are silently treated as helpers and
-never appear in the manifest.
+A theorem in the contract's proof namespace
+[`verity/proof/<Contract>Proof.lean`](verity/proof) whose conclusion is
+a spec application. Dischargers carry no Tama annotations: during
+`tama build`, Tama enumerates the theorems in the proof namespace from
+the elaborated Lean environment and, after stripping each theorem's
+leading non-`Prop` binders (the data inputs), records it as a discharger
+of a spec when its target is that spec application directly or a positive
+conjunction containing it. Discovery is file-layout independent — proofs
+may be split across imported submodules that share the proof namespace.
+One theorem can discharge several specs (via a conjunction), and several
+theorems can discharge one spec. Theorems whose target is anything else
+are treated as helpers and never appear in the manifest.
 
 ### Mirror test
 

--- a/site/src/pages/guides/audits.mdx
+++ b/site/src/pages/guides/audits.mdx
@@ -115,10 +115,10 @@ What it inspects:
 - Every spec has at least one discharger AND either at least one
   Foundry mirror or a [`[coverage.proof_only]`](/reference/config)
   entry in `tama.toml`.
-- Every `-- tama: discharges=<spec>` tag in the proof file names a
-  real top-level def in the same contract's spec file, and `tama build`
-  has checked that the tagged theorem target is the spec application or
-  a positive conjunction containing it.
+- Every spec has at least one discharger that `tama build` discovered
+  in the proof namespace — a theorem whose conclusion (after stripping
+  non-`Prop` binders) is the spec application or a positive conjunction
+  containing it.
 - Every `// tama: mirrors=<spec>` tag sits directly above a function
   named `testFuzz*` or `invariant_*`, and names a real spec in some
   contract.
@@ -164,7 +164,8 @@ trust-boundary: error
     depends on: sorryAx
 
   `sorry` is denied for any theorem that discharges a spec. Replace the
-  sorry with a real proof, or remove the `discharges=` tag.
+  sorry with a real proof, or change the theorem so its conclusion no
+  longer matches the spec.
 
 trust-boundary: warning
   TipJarProof.deposit_preserves_invariant

--- a/site/src/pages/guides/proofs.mdx
+++ b/site/src/pages/guides/proofs.mdx
@@ -44,13 +44,12 @@ discharger AND either at least one Foundry mirror test or a
 ## Discharging via proof
 
 In the proof file [`verity/proof/<Contract>Proof.lean`](verity/proof),
-each theorem that discharges an obligation carries a
-`-- tama: discharges=<spec_name>` comment directly above it:
+write the theorems that discharge your obligations with no Tama
+annotations — dischargers are auto-discovered by type:
 
 ```lean
 namespace FooProof
 
--- tama: discharges=total_in_range_after_mint
 theorem mint_preserves_total_in_range
     (pre : Foo.State) (call : Foo.Call) :
     FooSpec.total_in_range_after_mint pre call := by
@@ -62,29 +61,35 @@ theorem mint_preserves_total_in_range
 end FooProof
 ```
 
-The right-hand side is a comma-separated list of spec names from the
-same contract — no whitespace after commas:
+During `tama build`, Tama enumerates the theorems in the proof namespace
+from the elaborated Lean environment. For each one it strips the leading
+non-`Prop` binders (the data inputs) and inspects the conclusion. A
+theorem discharges a spec when that conclusion is the spec application
+directly, or a positive conjunction containing it — so a single theorem
+that proves a conjunction discharges every spec named in the conjunction:
 
 ```lean
--- tama: discharges=total_in_range,mint_increases_total
-theorem mint_combined : ... := by ...
+theorem mint_combined
+    (pre : Foo.State) (call : Foo.Call) :
+    FooSpec.total_in_range pre call ∧ FooSpec.mint_increases_total pre call := by ...
 ```
 
-Multiple theorems may discharge the same spec (cover one branch each,
-for instance), and one theorem may discharge several specs. Every name
-on the right of `discharges=` must be a real top-level def in the
-contract's spec file; an unknown name is a build error.
+Discovery is file-layout independent: the proof may be split across
+imported submodules, since all of them share the proof namespace. Tama
+finds the theorems wherever they live.
 
-Tama checks the elaborated theorem target in Lean. A tagged theorem must
-target the named spec application directly, or a positive conjunction
-containing it. `True`, unrelated specs, `P -> spec ...`, disjunctions,
-existentials, and helper-position mentions do not discharge the spec.
-Put preconditions inside the spec definition, then unfold the spec in
-the proof and introduce those assumptions there.
+The discharge criterion is exactly the elaborated conclusion. A theorem
+discharges a spec only if, after stripping non-`Prop` binders, its
+conclusion is the spec application or a positive conjunction containing
+it. `True`, unrelated specs, `P -> spec ...`, disjunctions, existentials,
+and helper-position mentions do not discharge the spec. Put preconditions
+inside the spec definition, then unfold the spec in the proof and
+introduce those assumptions there.
 
-Theorems and `lemma`s without a `discharges=` tag are silently treated
-as helpers — Tama never reads them and the manifest never mentions
-them. Tag the ones that close obligations; leave the scaffolding alone.
+Theorems whose conclusion is anything else are treated as helpers — they
+never appear in the manifest. There is nothing to tag: write the
+obligation-closing theorems in the spec-application shape and leave the
+scaffolding alone.
 
 ## Discharging via mirror
 
@@ -144,7 +149,6 @@ The intent: keep working contracts in a half-proven state during
 development; gate releases on a real proof.
 
 ```lean
--- tama: discharges=withdraw_drops_total
 theorem withdraw_drops_total : ... := by
   sorry  -- ok locally, will fail audit
 ```
@@ -188,7 +192,7 @@ anything you allowlist is a project-level choice, not a framework one.
   catalogues the common error messages and tactic patterns from the
   Verity side — start here before reaching for `sorry`.
 - Read [the audit guide](/guides/audits) — many "proof failures" are
-  actually structural mistakes (e.g. a `discharges=` tag pointing at a
-  spec name that doesn't exist, or a theorem target that does not
+  actually structural mistakes (e.g. a spec with no theorem whose
+  conclusion is its application, or a theorem target that does not
   actually contain the spec application) that the build reports before
   audit inputs are written.

--- a/site/src/pages/guides/starter.mdx
+++ b/site/src/pages/guides/starter.mdx
@@ -223,7 +223,6 @@ open Verity.EVM.Uint256
 open MyProtocol.Spec.ERC20LiteSpec
 open MyProtocol.ERC20Lite
 
--- tama: discharges=transfer_total_supply_preserved
 theorem transfer_total_supply_preserved_after_run
     (toAddr : Address) (amount : Uint256) (s : ContractState) :
     let s' := ((transfer toAddr amount).run s).snd
@@ -252,7 +251,6 @@ implication's antecedent, and they `intro` the precondition before
 discharging the conjunction:
 
 ```lean
--- tama: discharges=transferOwnership_authorized_sets_owner
 theorem transferOwnership_authorized_sets_owner_after_run
     (newOwner : Address) (s : ContractState) :
     transferOwnership_authorized_sets_owner newOwner s
@@ -275,14 +273,14 @@ while leaving `sub` alone, so the sender side has to be canonicalized
 by hand.)
 
 The model is symmetric. The spec file declares an obligation by
-defining `transfer_total_supply_preserved`; the proof claims it with
-`-- tama: discharges=transfer_total_supply_preserved` directly above
-the theorem, and Lean checks that the theorem target is that spec
-application; the Foundry test mirrors it with a matching
+defining `transfer_total_supply_preserved`; the proof discharges it by
+making a theorem's conclusion that spec application (no annotation
+needed — `tama build` discovers it by type from the proof namespace);
+the Foundry test mirrors it with a matching
 `// tama: mirrors=transfer_total_supply_preserved` (next section).
-Theorems and `lemma`s without a `discharges=` tag are silently treated
-as helpers; the ten other obligations each carry their own
-`discharges=` tag pointing at the matching spec def, and each spec is
+Theorems whose conclusion is anything other than a spec application are
+treated as helpers; the ten other obligations each have at least one
+theorem whose conclusion is the matching spec def, and each spec is
 mirrored by at least one `testFuzz_*` (or `invariant_*`) function in
 the Foundry test file.
 

--- a/site/src/pages/reference/cli.mdx
+++ b/site/src/pages/reference/cli.mdx
@@ -140,12 +140,13 @@ Steps:
 1. `lake build MyProtocol.Proof` — Lean elaborates implementation, spec, and proof. The target is the configured proof aggregate module; legacy projects without `[modules]` use `TamaProof`.
 2. `lake exe verity-compiler` — emits Yul, ABI, storage, trust reports.
 3. Tama adapts compiler output into `tama.contract-manifest.v1` files.
-4. Lean validates `discharges=` claims and records proof dependencies into `artifacts/trust-probe/axioms.json`.
-5. Tama validates each manifest's schema and artifact paths.
-6. `solc --standard-json` compiles each Yul into bytecode per `[yul]`.
-7. Tama generates Solidity interfaces and deployers from the manifests.
-8. `forge build` compiles user Solidity, generated bridges, and tests.
-9. `tama.lock` is refreshed.
+4. A Lean meta-pass discovers each spec's dischargers by type — enumerating the theorems in the contract's proof namespace and recording those whose elaborated conclusion (after stripping non-`Prop` binders) is the spec application or a positive conjunction containing it — and records them in the manifest's `dischargers` arrays.
+5. Lean's trust probe collects the axioms reachable from every discharger and records proof dependencies into `artifacts/trust-probe/axioms.json`.
+6. Tama validates each manifest's schema and artifact paths.
+7. `solc --standard-json` compiles each Yul into bytecode per `[yul]`.
+8. Tama generates Solidity interfaces and deployers from the manifests.
+9. `forge build` compiles user Solidity, generated bridges, and tests.
+10. `tama.lock` is refreshed.
 
 Useful flags:
 

--- a/site/src/pages/reference/manifest.mdx
+++ b/site/src/pages/reference/manifest.mdx
@@ -176,7 +176,7 @@ One entry per top-level definition in the spec file.
 | `name`               | Spec definition name as written.                                         |
 | `lean_decl`          | Fully qualified Lean declaration name of the spec def.                   |
 | `contract`           | The contract this obligation belongs to.                                 |
-| `dischargers`        | Array of fully qualified theorem decls (proof side) that discharge this. |
+| `dischargers`        | Array of fully qualified theorem decls (proof side) that discharge this, auto-discovered by type from the proof namespace during `tama build`. |
 | `mirrors`            | Array of `<file>:<sol_contract>.<sol_function>` mirror references.       |
 | `proof_only_reason`  | Non-empty string from `[coverage.proof_only]`, or `null`.                |
 

--- a/site/src/pages/start.mdx
+++ b/site/src/pages/start.mdx
@@ -205,10 +205,9 @@ the source of public proof obligations.
 ## Step 5: Read the proof links
 
 Open `verity/proof/MyProtocol/Proof/ERC20LiteProof.lean`. Proof theorems are
-ordinary Lean declarations with a Tama comment directly above the theorem:
+ordinary Lean declarations — no Tama annotation is needed:
 
 ```lean
--- tama: discharges=balanceOf_spec
 theorem balanceOf_returns_storage_balance (account : Address) (s : ContractState) :
   let result := ((balanceOf account).run s).fst
   balanceOf_spec account result s := by
@@ -216,11 +215,14 @@ theorem balanceOf_returns_storage_balance (account : Address) (s : ContractState
 ```
 
 The generated file also contains larger state-transition proofs with case
-splits for `mint`, `transfer`, and `transferOwnership`. The important contract
-with Tama is the comment: `-- tama: discharges=balanceOf_spec` tells the audit
-which spec obligation this theorem proves.
+splits for `mint`, `transfer`, and `transferOwnership`. Tama discovers which
+obligation each theorem proves from the elaborated environment: a theorem
+discharges a spec when its conclusion — after stripping the data inputs — is
+that spec applied (or a positive conjunction containing it).
+`balanceOf_returns_storage_balance` concludes `balanceOf_spec …`, so it
+discharges `balanceOf_spec`.
 
-Theorems and lemmas without `discharges=` are helper facts. They can make the
+Theorems whose conclusion is anything else are helper facts. They can make the
 proof easier to read, but they do not appear as release obligations.
 
 ## Step 6: Check implementation and spec
@@ -264,6 +266,8 @@ Build steps:
   ok   verity-codegen  compiler artifacts generated
   run  manifest        Tama adapts Verity outputs into contract manifests
   ok   manifest        1 manifest: ERC20Lite
+  run  dischargers     Lean discovers proof dischargers by spec type
+  ok   dischargers     dischargers resolved
   run  trust-probe     Lean validates dischargers and records proof dependencies
   ok   trust-probe     trust-boundary inputs written
   run  validate        ERC20Lite manifest schema and artifact paths


### PR DESCRIPTION
## Problem

`tama build` failed at manifest validation whenever a contract's proof was split across multiple files:

```
obligation <Contract>.<spec> requires at least one discharger.
```

**Root cause.** `discover_contract_sources` resolves each contract's proof to the single `{Contract}Proof.lean`, and `extract_dischargers` regex-scanned *only that file* for `-- tama: discharges=` tags. When a proof is split into submodules — the top-level `{Contract}Proof.lean` carries only `import`s while the discharge tags live in the imported sub-files — that top-level file is tag-less, so Tama recorded zero dischargers for the contract and `manifest.validate()` rejected its first obligation. The proof itself is valid; the single-file scanner simply outran the proof split.

## Fix

Replace the single-file comment scan with **namespace + type-based discovery via the elaborated Lean environment**. A new `discover_dischargers` build step writes a generated Lean meta-file, enumerates the theorems in each contract's proof namespace, and records a theorem as a discharger of a spec when its final target — after stripping the leading non-`Prop` binders — is the spec application or a positive conjunction containing it.

Why this shape:

- **File-layout independent.** Discovery keys off the proof *namespace*, not the filesystem, so a proof in 1 file or 8 is handled identically (all submodules share the namespace). No sibling-directory walking or other brittle heuristics.
- **Source of truth is the elaborated environment**, not comment text plus a theorem regex.
- **Reuses existing machinery.** The discharge criterion (`tamaFinalTheoremTarget` + `tamaTargetContainsSpec`) is factored into one shared `const` used by *both* discovery and the trust probe, so both judge dischargers identically.

### Soundness is unchanged

Discovery applies the **same** criterion the trust probe already enforced on tagged dischargers: after stripping non-`Prop` binders, the conclusion must be the spec applied (or a positive `And` of specs). Theorems with extra hypotheses (`P → spec …`), disjunctions, existentials, `True`, or helper-position mentions are rejected — confirmed empirically against the fixture (a precondition, a trivially-true `True →` precondition, and a `spec ∨ …` weakening are all refused; a direct conclusion is accepted). Because every previously-valid tagged discharger already passed this check and lives in the proof namespace, discovery is a coverage **superset** with **identical per-discharger soundness**; the trust probe still collects axioms for each.

The `-- tama: discharges=` tag is gone: no longer written, parsed, or required. Leftover tags in existing proofs are inert.

## Changes

- `crates/tama-build`: `discover_dischargers` / `discover_dischargers_source` / `parse_discharger_output`, shared `TAMA_TARGET_HELPERS`, a new `dischargers` pipeline step (before trust-probe/validate). `adapt_verity_outputs` builds obligations with empty dischargers and no longer writes the manifest — the `discover_dischargers` step is the first, validated, writer, so a failed build never leaves an invalid manifest on disk. `extract_dischargers` and all tag parsing removed.
- Counter fixture proof split across `CounterProofParts.lean` (sharing the `proof.CounterProof` namespace) with no tags, so the e2e exercises the split, tag-free path that triggered the bug.
- Starter template + docs (`SPEC.md`, site guides/reference) drop tag authoring and describe auto-discovery, keeping the accepted/rejected target-shape criterion.
- Workspace version → `0.1.6`.

## Testing

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` — all green.
- Real end-to-end `tama build` of the split, tag-free counter fixture (local Lean/Lake): `proof-check` builds both `CounterProofParts` and `CounterProof`; `dischargers` resolves all four obligations to the correct theorems (including the two now in the submodule); trust-probe and validate pass.
- Unit tests cover the generated Lean source, the marker parser (including the zero-discharger error), and nested-namespace dispatch. The CI counter e2e now covers the split scenario.

## Release

This bumps the workspace to `0.1.6`. Cutting the release is the usual maintainer step: push tag `v0.1.6` after merge (the release CI validates package versions against the tag and runs the full Lean/solc/Foundry e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
