### PR TITLE
ci: reclaim disk in negative-audit so the runner doesn't fill up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,10 @@ jobs:
 
           copy_case() {
             name="$1"
+            # Reclaim disk from earlier cases: keep only `base` plus the case
+            # being created so the mutation copies never accumulate and fill
+            # the runner disk.
+            find "$TAMA_NEGATIVE_TMP" -mindepth 1 -maxdepth 1 -type d ! -name base -exec rm -rf {} +
             target="$TAMA_NEGATIVE_TMP/$name"
             cp -R "$base" "$target"
             printf '%s\n' "$target"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,6 +275,10 @@ jobs:
 
           copy_case() {
             name="$1"
+            # Reclaim disk from earlier cases: keep only `base` plus the case
+            # being created so the mutation copies never accumulate and fill
+            # the runner disk.
+            find "$TAMA_RELEASE_NEGATIVE_TMP" -mindepth 1 -maxdepth 1 -type d ! -name base -exec rm -rf {} +
             target="$TAMA_RELEASE_NEGATIVE_TMP/$name"
             cp -R "$base" "$target"
             printf '%s\n' "$target"


### PR DESCRIPTION
## Problem

The v0.1.6 **Release** run failed: the `Release negative audit` job died with

```
Unhandled exception. System.IO.IOException: No space left on device
```

The job's "Mutated audits fail closed" step reported a `null` conclusion with no captured logs (the runner crashed mid-step), and the dependent `Build` / `Publish signed release` jobs were skipped — so nothing was published.

## Root cause

The step does ~14 `copy_case` calls, each `cp -R "$base" "$target"` of the **fully-built** ERC20Lite project (artifacts, solc output, forge `out/`, generated bridges), and never deletes the copies. All 14 accumulate on top of the release `target/`, exhausting the runner disk. The real e2e, installer-safety, and version jobs all passed — this is purely disk pressure in the mutation harness, not a product bug.

## Fix

`copy_case` now reclaims earlier case directories (keeping only `base`) before creating the next one, bounding disk to one mutated copy at a time:

```bash
find "$TMP" -mindepth 1 -maxdepth 1 -type d ! -name base -exec rm -rf {} +
```

Applied to the negative-audit job in both `release.yml` and `ci.yml` (same latent bug; the CI job just hadn't tipped over yet). Each case is independent (copied fresh from `base`) and its assertion completes before the next `copy_case`, so deleting prior copies is safe.

Verified locally that successive `copy_case` calls leave only `base` + the current case, and that `find`'s `set -x` trace (stderr) does not pollute the captured `$(...)` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)