### PR TITLE
Fix linux-aarch64 solc download path that aborts the installer on ARM Linux

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -87,7 +87,10 @@ SOLC_BIN="$SOLC_DIR/solc"
 if [ ! -x "$SOLC_BIN" ]; then
   case "$PLATFORM" in
     linux-x86_64)  SOLC_URL_PATH="linux-amd64/solc-linux-amd64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
-    linux-aarch64) SOLC_URL_PATH="linux-aarch64/solc-linux-aarch64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
+    # Solidity publishes the native ARM build under "linux-arm64". Mind the
+    # spelling: this script's PLATFORM token is "linux-aarch64", but the URL
+    # segment has to be "linux-arm64".
+    linux-aarch64) SOLC_URL_PATH="linux-arm64/solc-linux-arm64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
     macos-aarch64) SOLC_URL_PATH="macosx-amd64/solc-macosx-amd64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
     *) echo "no solc binary mapping for platform: $PLATFORM" >&2; exit 1 ;;
   esac

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -52,7 +52,11 @@ else
     ELAN="$HOME/.elan/bin/elan"
   fi
   echo "Ensuring Lean toolchain $LEAN_TOOLCHAIN is installed..."
-  "$ELAN" toolchain install "$LEAN_TOOLCHAIN"
+  # elan errors (and, under set -e, aborts the installer) if the toolchain is
+  # already installed, which breaks re-runs. Only install when it is missing.
+  if ! "$ELAN" toolchain list 2>/dev/null | grep -qF "$LEAN_TOOLCHAIN"; then
+    "$ELAN" toolchain install "$LEAN_TOOLCHAIN"
+  fi
   # Set as elan's default only if no default is currently configured, so we
   # don't clobber an existing user pin. settings.toml carries
   # `default_toolchain = "<name>"` when one is set.

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -87,7 +87,10 @@ SOLC_BIN="$SOLC_DIR/solc"
 if [ ! -x "$SOLC_BIN" ]; then
   case "$PLATFORM" in
     linux-x86_64)  SOLC_URL_PATH="linux-amd64/solc-linux-amd64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
-    linux-aarch64) SOLC_URL_PATH="linux-aarch64/solc-linux-aarch64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
+    # Solidity publishes the native ARM build under "linux-arm64". Mind the
+    # spelling: this script's PLATFORM token is "linux-aarch64", but the URL
+    # segment has to be "linux-arm64".
+    linux-aarch64) SOLC_URL_PATH="linux-arm64/solc-linux-arm64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
     macos-aarch64) SOLC_URL_PATH="macosx-amd64/solc-macosx-amd64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
     *) echo "no solc binary mapping for platform: $PLATFORM" >&2; exit 1 ;;
   esac

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -52,7 +52,11 @@ else
     ELAN="$HOME/.elan/bin/elan"
   fi
   echo "Ensuring Lean toolchain $LEAN_TOOLCHAIN is installed..."
-  "$ELAN" toolchain install "$LEAN_TOOLCHAIN"
+  # elan errors (and, under set -e, aborts the installer) if the toolchain is
+  # already installed, which breaks re-runs. Only install when it is missing.
+  if ! "$ELAN" toolchain list 2>/dev/null | grep -qF "$LEAN_TOOLCHAIN"; then
+    "$ELAN" toolchain install "$LEAN_TOOLCHAIN"
+  fi
   # Set as elan's default only if no default is currently configured, so we
   # don't clobber an existing user pin. settings.toml carries
   # `default_toolchain = "<name>"` when one is set.


### PR DESCRIPTION
I tried to `curl | sh` the tama installer on an arm64 Linux box and it quit before tama was ever installed. The solc download 404s on ARM, and since the script runs under `set -eu`, that one failed fetch takes the whole installer down with it. What you're left with is an empty `~/.tama/solc/0.8.33/` and no `tama` on your PATH, and nothing telling you why.

Repro on any linux-aarch64 machine (Graviton, Ampere, Apple-Silicon-Linux, a Pi):

```
curl -L https://tama.tools/install.sh | sh
...
Installing solc 0.8.33 to ~/.tama/solc/0.8.33/solc...
curl: (22) The requested URL returned error: 404
```

### The actual bug

My first instinct was that Solidity just doesn't publish an ARM Linux solc, and I almost opened a PR pulling it from a third-party mirror. I was wrong. The binary is sitting on the official host the whole time, the installer is just asking for the wrong path. solc ships the ARM build under `linux-arm64`, but the script's platform token is `linux-aarch64` and it reuses that spelling to build the URL:

```sh
linux-aarch64) SOLC_URL_PATH="linux-aarch64/solc-linux-aarch64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
```

`linux-aarch64/...` 404s. `linux-arm64/...` is a 200 and a native aarch64 binary. I checked by hand on this box:

```
.../linux-aarch64/solc-linux-aarch64-v0.8.33+commit.64118f21  ->  404   (what the script asks for)
.../linux-arm64/solc-linux-arm64-v0.8.33+commit.64118f21      ->  200   (native aarch64, reports 0.8.33+commit.64118f21.Linux.g++)
.../linux-arm64/list.json                                       ->  200   (0.8.33, 0.8.34, 0.8.35 all there)
```

### The fix

You can point the aarch64 case at the right path on the same official host:

```sh
linux-aarch64) SOLC_URL_PATH="linux-arm64/solc-linux-arm64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
```

It's the same host the other platforms already use, so there's no new dependency and no new trust to think about. I left a one-line comment next to it so nobody "corrects" `arm64` back to `aarch64` down the line.

### A second commit, optional

While re-running the installer (which is what you do after the failure above), I hit another wall. `"$ELAN" toolchain install "$LEAN_TOOLCHAIN"` errors out if that toolchain is already installed, and `set -e` turns it into another abort. I guarded it so a re-run is safe:

```sh
if ! "$ELAN" toolchain list 2>/dev/null | grep -qF "$LEAN_TOOLCHAIN"; then
  "$ELAN" toolchain install "$LEAN_TOOLCHAIN"
fi
```

Happy to drop it or move it to its own PR if you'd rather keep this one to the solc path.

### Why two files change

`installer/install.sh` and `site/public/install.sh` are checked in identical, and `deploy-docs.yml` re-syncs the site copy from the canonical one on deploy. The buggy bytes live in both today, so I patched both and the tree stays honest.

### How I tested it

- Confirmed the URLs above by hand on this aarch64 box (the 404, the 200, the version string it prints).
- `sh -n` and `bash -n` are clean on both files, and `shellcheck -S warning` is quiet.
- Ran the full installer with the fix and it went all the way through: solc and tama both land, `tama doctor` comes back green, and I built and deployed a contract to Monad testnet against that solc.
- `git apply --check` is clean against a fresh `main`.

`macos-aarch64` still pulls the `macosx-amd64` build and runs it under Rosetta. I didn't touch that. There's a native `macosx-arm64` on the same host now if you want a follow-up.

One unrelated thing I noticed: there's no LICENSE file even though `Cargo.toml` says MIT. Might be worth adding one so outside PRs have clear terms. I can send that separately.

---
