### PR TITLE
👷 Fix SOLC path issue

### DIFF
--- a/crates/tama-cli/src/main.rs
+++ b/crates/tama-cli/src/main.rs
@@ -882,6 +882,21 @@ fn doctor_report(project: Option<&Utf8PathBuf>) -> Result<tama_toolchain::Doctor
             }
         }
         if let Some(config) = &config {
+            if let Ok(path) = tama_toolchain::resolve_solc_path(project_root, &config.yul.solc) {
+                let version = tama_toolchain::tool_version("solc", &path).ok();
+                if let Some(status) = report.tools.iter_mut().find(|s| match s {
+                    tama_toolchain::ToolStatus::Ok(t) => t.name == "solc",
+                    tama_toolchain::ToolStatus::Missing { name, .. } => name == "solc",
+                    tama_toolchain::ToolStatus::Incompatible { name, .. } => name == "solc",
+                }) {
+                    *status = tama_toolchain::ToolStatus::Ok(tama_toolchain::Tool {
+                        name: "solc".to_string(),
+                        path,
+                        version,
+                    });
+                }
+            }
+
             mark_version_mismatch(
                 &mut report,
                 "solc",

--- a/crates/tama-toolchain/src/lib.rs
+++ b/crates/tama-toolchain/src/lib.rs
@@ -384,7 +384,7 @@ pub fn parse_expected_version(tool: &str, version: &str) -> Result<Version> {
     })
 }
 
-fn resolve_solc_path(root: &Utf8Path, expected: &str) -> Result<Utf8PathBuf> {
+pub fn resolve_solc_path(root: &Utf8Path, expected: &str) -> Result<Utf8PathBuf> {
     if let Ok(path) = std::env::var("TAMA_SOLC") {
         return Ok(Utf8PathBuf::from(path));
     }


### PR DESCRIPTION
Fix `SOLC` binary doesn't detect at `tama doctor`

```
tama doctor
Doctor scope:
  project: .
  repair: disabled

Steps:
  ok   report       diagnostics collected
Checks:
  ok   tama            0.1.6
  ok   lean            4.22.0
  ok   lake            5.0.0-src+ba2cbbf (Lean version 4.22.0)
  ok   forge           1.5.1-stable
  fail solc            install solc 0.8.33 or set TAMA_SOLC to a matching binary
  ok   git             2.50.1 (Apple Git-155)
  ok   tar             bsdtar 3.5.3 - libarchive 3.7.4 zlib/1.2.12 liblzma/5.4.3 bz2lib/1.0.8
  ok   lake buildDir   artifacts/lean
  ok   verity          requested 9b0114efcc0af589af63dd3f2eafcdf1a24dbf1e, resolved 9b0114efcc0af589af63dd3f2eafcdf1a24dbf1e
  ok   lock            current

Doctor found issues: 10 checks, 1 issue
```