### PR TITLE
Fix solc URL path for linux-aarch64 platform

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -87,7 +87,7 @@ SOLC_BIN="$SOLC_DIR/solc"
 if [ ! -x "$SOLC_BIN" ]; then
   case "$PLATFORM" in
     linux-x86_64)  SOLC_URL_PATH="linux-amd64/solc-linux-amd64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
-    linux-aarch64) SOLC_URL_PATH="linux-aarch64/solc-linux-aarch64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
+    linux-aarch64) SOLC_URL_PATH="linux-arm64/solc-linux-arm64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
     macos-aarch64) SOLC_URL_PATH="macosx-amd64/solc-macosx-amd64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
     *) echo "no solc binary mapping for platform: $PLATFORM" >&2; exit 1 ;;
   esac


### PR DESCRIPTION
solc-bin aarch64 are actually in arm64 folder - https://github.com/argotorg/solc-bin/tree/gh-pages