### PR TITLE
Accept externalSummary assumption category in trust-boundary audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "tama-audit"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "camino",
  "regex",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "tama-build"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "camino",
  "regex",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "tama-cli"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "tama-common"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "camino",
  "hex",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "tama-config"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "camino",
  "serde",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "tama-inspect"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "camino",
  "serde",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "tama-manifest"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "camino",
  "regex",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "tama-project"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "camino",
  "serde",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "tama-toolchain"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "camino",
  "hex",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "tamaup-cli"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.1.6"
+version = "0.1.7"
 rust-version = "1.81"
 license = "MIT"
 authors = ["zefram.eth"]

--- a/crates/tama-audit/src/lib.rs
+++ b/crates/tama-audit/src/lib.rs
@@ -2142,6 +2142,9 @@ fn audit_assumption_entry(
         "linkedExternal" => {
             check_axiom_array(ctx, contract_name, entry, name, "linked external", issues)
         }
+        "externalSummary" => {
+            check_axiom_array(ctx, contract_name, entry, name, "external summary", issues)
+        }
         "ecmAxiom" => check_allowed_assumption(ctx, contract_name, name, "ECM axiom", issues),
         "localObligation" => issues.push(issue(
             "trust-boundary",
@@ -2871,6 +2874,47 @@ solc = "0.8.33"
         assert!(issues.iter().any(|issue| {
             issue.code == "TAMA_TRUST_ASSUMPTION"
                 && issue.message.contains("keccak256_memory_slice_matches_evm")
+        }));
+    }
+
+    #[test]
+    fn assumption_report_fails_on_unallowlisted_external_summary_axiom() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+        let config = test_config();
+        tama_common::write_string(
+            &root.join("artifacts/assumption-report.json"),
+            r#"{"contracts":[{"contract":"Counter","entries":[],"undischarged":[{"category":"externalSummary","siteKind":"function","siteName":"pull","name":"foglightPoolSummary","status":"assumed","detail":"","assumption":"","module":"","axioms":["foglight_pool_summary_matches_impl"]}]}]}"#,
+        )
+        .unwrap();
+        let mut issues = Vec::new();
+        trust(&root, &config, &[counter_manifest()], &mut issues);
+        assert!(issues.iter().any(|issue| {
+            issue.code == "TAMA_TRUST_ASSUMPTION"
+                && issue.message.contains("external summary")
+                && issue.message.contains("foglight_pool_summary_matches_impl")
+        }));
+    }
+
+    #[test]
+    fn assumption_report_accepts_allowlisted_external_summary_axiom() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+        let mut config = test_config();
+        config.trust.allow_axioms.insert(
+            "foglight_pool_summary_matches_impl".to_string(),
+            "Accepted summarized FoglightPool external call".to_string(),
+        );
+        tama_common::write_string(
+            &root.join("artifacts/assumption-report.json"),
+            r#"{"contracts":[{"contract":"Counter","entries":[],"undischarged":[{"category":"externalSummary","siteKind":"function","siteName":"pull","name":"foglightPoolSummary","status":"assumed","detail":"","assumption":"","module":"","axioms":["foglight_pool_summary_matches_impl"]}]}]}"#,
+        )
+        .unwrap();
+        let mut issues = Vec::new();
+        trust(&root, &config, &[counter_manifest()], &mut issues);
+        assert!(!issues.iter().any(|issue| {
+            issue.code == "TAMA_TRUST_ASSUMPTION"
+                || issue.code == "TAMA_TRUST_ASSUMPTION_REPORT_INVALID"
         }));
     }
 


### PR DESCRIPTION
## Summary

`tama audit`'s `trust-boundary` check rejected the `externalSummary` assumption category that the verity compiler (driven by `tama build`) writes into `artifacts/assumption-report.json` for summarized linked-external calls. The validator matched a closed set of categories that omitted `externalSummary`, so entries fell through to the `_ =>` arm and raised `TAMA_TRUST_ASSUMPTION_REPORT_INVALID` — meaning a clean build could not pass its own audit. This was not fixable from a consuming repo (the category is generated, not authored, and no `tama.toml` key controls it).

## Changes

- Add an `externalSummary` arm to `audit_assumption_entry` in `crates/tama-audit/src/lib.rs`, reusing the same `check_axiom_array` allowlist validation as `linkedExternal`. The summarized call is trusted only to the extent its declared `axioms[]` are present and allowlisted via `trust.allow_axioms`; an unallowlisted axiom still raises `TAMA_TRUST_ASSUMPTION`, keeping the trust boundary intact.
- Add tests covering both the reject (unallowlisted axiom) and accept (allowlisted axiom) paths.
- Bump the workspace version `0.1.6` → `0.1.7` for the release carrying this fix.

## Verification

- `cargo test -p tama-audit` — 44 passed.
- `cargo clippy -p tama-audit` — clean.
- `cargo build` — green (lockfile updated to 0.1.7).

Note: the emitter side lives in the external verity compiler (invoked via `--assumption-report` in `tama-build`), so only the validator needed to learn the category the compiler already produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PuAMG3RDNS2B7kGN3zHnq

---
_Generated by [Claude Code](https://claude.ai/code/session_013PuAMG3RDNS2B7kGN3zHnq)_