### PR TITLE
Fix linux-aarch64 solc download path that aborts the installer on ARM Linux

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -52,7 +52,11 @@ else
     ELAN="$HOME/.elan/bin/elan"
   fi
   echo "Ensuring Lean toolchain $LEAN_TOOLCHAIN is installed..."
-  "$ELAN" toolchain install "$LEAN_TOOLCHAIN"
+  # elan errors (and, under set -e, aborts the installer) if the toolchain is
+  # already installed, which breaks re-runs. Only install when it is missing.
+  if ! "$ELAN" toolchain list 2>/dev/null | grep -qF "$LEAN_TOOLCHAIN"; then
+    "$ELAN" toolchain install "$LEAN_TOOLCHAIN"
+  fi
   # Set as elan's default only if no default is currently configured, so we
   # don't clobber an existing user pin. settings.toml carries
   # `default_toolchain = "<name>"` when one is set.
@@ -87,7 +91,10 @@ SOLC_BIN="$SOLC_DIR/solc"
 if [ ! -x "$SOLC_BIN" ]; then
   case "$PLATFORM" in
     linux-x86_64)  SOLC_URL_PATH="linux-amd64/solc-linux-amd64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
-    linux-aarch64) SOLC_URL_PATH="linux-aarch64/solc-linux-aarch64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
+    # Solidity publishes the native ARM build under "linux-arm64". Mind the
+    # spelling: this script's PLATFORM token is "linux-aarch64", but the URL
+    # segment has to be "linux-arm64".
+    linux-aarch64) SOLC_URL_PATH="linux-arm64/solc-linux-arm64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
     macos-aarch64) SOLC_URL_PATH="macosx-amd64/solc-macosx-amd64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
     *) echo "no solc binary mapping for platform: $PLATFORM" >&2; exit 1 ;;
   esac

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -52,7 +52,11 @@ else
     ELAN="$HOME/.elan/bin/elan"
   fi
   echo "Ensuring Lean toolchain $LEAN_TOOLCHAIN is installed..."
-  "$ELAN" toolchain install "$LEAN_TOOLCHAIN"
+  # elan errors (and, under set -e, aborts the installer) if the toolchain is
+  # already installed, which breaks re-runs. Only install when it is missing.
+  if ! "$ELAN" toolchain list 2>/dev/null | grep -qF "$LEAN_TOOLCHAIN"; then
+    "$ELAN" toolchain install "$LEAN_TOOLCHAIN"
+  fi
   # Set as elan's default only if no default is currently configured, so we
   # don't clobber an existing user pin. settings.toml carries
   # `default_toolchain = "<name>"` when one is set.
@@ -87,7 +91,10 @@ SOLC_BIN="$SOLC_DIR/solc"
 if [ ! -x "$SOLC_BIN" ]; then
   case "$PLATFORM" in
     linux-x86_64)  SOLC_URL_PATH="linux-amd64/solc-linux-amd64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
-    linux-aarch64) SOLC_URL_PATH="linux-aarch64/solc-linux-aarch64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
+    # Solidity publishes the native ARM build under "linux-arm64". Mind the
+    # spelling: this script's PLATFORM token is "linux-aarch64", but the URL
+    # segment has to be "linux-arm64".
+    linux-aarch64) SOLC_URL_PATH="linux-arm64/solc-linux-arm64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
     macos-aarch64) SOLC_URL_PATH="macosx-amd64/solc-macosx-amd64-v${SOLC_VERSION}+commit.${SOLC_COMMIT}" ;;
     *) echo "no solc binary mapping for platform: $PLATFORM" >&2; exit 1 ;;
   esac


### PR DESCRIPTION
## Summary

On ARM Linux the installer 404s fetching solc and, running under `set -eu`, aborts before tama is ever installed — leaving an empty `~/.tama/solc/0.8.33/` and no `tama` on PATH. Solidity publishes the native ARM build under `linux-arm64`, but the script reuses its own `linux-aarch64` PLATFORM token to build the URL (`linux-aarch64/solc-linux-aarch64-...`), which does not exist. Pointing the aarch64 case at `linux-arm64/solc-linux-arm64-...` on the same official host is a 200 and a native aarch64 binary — no new host or trust surface.

A second, related fix guards the elan toolchain install: `elan toolchain install` errors when the toolchain is already present, which under `set -e` aborts a re-run (exactly what a user does after the solc failure). It now only installs when the toolchain is missing.

`installer/install.sh` and `site/public/install.sh` are checked in identical and re-synced on deploy, so both are patched.

## Changes

- `installer/install.sh`, `site/public/install.sh`: aarch64 solc URL path `linux-aarch64` → `linux-arm64` (with a comment so it isn't "corrected" back); guard `elan toolchain install` behind a presence check for safe re-runs.

## Verification

- `sh -n` clean on both scripts; both copies are byte-identical.

## Credit

This recreates the fix from #35 by @portdeveloper as a signed commit so it satisfies the branch's require-signed-commits rule (the fork commits could not be signed in place). Supersedes #39, which addressed only the solc path. Closes #35 and #39 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PuAMG3RDNS2B7kGN3zHnq

---
_Generated by [Claude Code](https://claude.ai/code/session_013PuAMG3RDNS2B7kGN3zHnq)_