### PR TITLE
Make tama doctor detect the tama-managed solc install

### DIFF
--- a/crates/tama-cli/src/main.rs
+++ b/crates/tama-cli/src/main.rs
@@ -882,6 +882,21 @@ fn doctor_report(project: Option<&Utf8PathBuf>) -> Result<tama_toolchain::Doctor
             }
         }
         if let Some(config) = &config {
+            if let Ok(path) = tama_toolchain::resolve_solc_path(project_root, &config.yul.solc) {
+                let version = tama_toolchain::tool_version("solc", &path).ok();
+                if let Some(status) = report.tools.iter_mut().find(|s| match s {
+                    tama_toolchain::ToolStatus::Ok(t) => t.name == "solc",
+                    tama_toolchain::ToolStatus::Missing { name, .. } => name == "solc",
+                    tama_toolchain::ToolStatus::Incompatible { name, .. } => name == "solc",
+                }) {
+                    *status = tama_toolchain::ToolStatus::Ok(tama_toolchain::Tool {
+                        name: "solc".to_string(),
+                        path,
+                        version,
+                    });
+                }
+            }
+
             mark_version_mismatch(
                 &mut report,
                 "solc",

--- a/crates/tama-toolchain/src/lib.rs
+++ b/crates/tama-toolchain/src/lib.rs
@@ -384,7 +384,7 @@ pub fn parse_expected_version(tool: &str, version: &str) -> Result<Version> {
     })
 }
 
-fn resolve_solc_path(root: &Utf8Path, expected: &str) -> Result<Utf8PathBuf> {
+pub fn resolve_solc_path(root: &Utf8Path, expected: &str) -> Result<Utf8PathBuf> {
     if let Ok(path) = std::env::var("TAMA_SOLC") {
         return Ok(Utf8PathBuf::from(path));
     }


### PR DESCRIPTION
## Summary

`tama doctor` looked up solc only on `PATH`, so a solc installed by the tama installer under `~/.tama/solc/<version>/solc` was reported as `fail solc  install solc 0.8.33 or set TAMA_SOLC to a matching binary` even though `tama build` uses exactly that binary. Doctor now resolves solc the same way the build does and reports the resolved binary.

## Changes

- `crates/tama-toolchain/src/lib.rs`: make `resolve_solc_path` public so the CLI can reuse the build's solc resolution.
- `crates/tama-cli/src/main.rs`: in `doctor_report`, resolve solc via `resolve_solc_path(project_root, &config.yul.solc)`; when it resolves, replace the solc entry in the report with an `Ok` status carrying the resolved path and its `--version`.

## Verification

- `cargo build -p tama-cli -p tama-toolchain` — green.
- `cargo clippy -p tama-cli -p tama-toolchain` — clean.

## Credit

This recreates the fix from #38 by @atarpara as a signed commit so it satisfies the branch's require-signed-commits rule (the fork commit could not be signed in place). Closes #38 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PuAMG3RDNS2B7kGN3zHnq

---
_Generated by [Claude Code](https://claude.ai/code/session_013PuAMG3RDNS2B7kGN3zHnq)_